### PR TITLE
Getting tests passing for github handler, tidying up coding standards

### DIFF
--- a/lib/GithubHandler.js
+++ b/lib/GithubHandler.js
@@ -1,12 +1,9 @@
-var path = require('path')
-  , http = require('http')
-  , async = require('async')
-  , restify = require('restify')
-  , request = require('request')
-  , createWebhookHandler = require('github-webhook-handler')
-  , bunyan = require('bunyan')
-  , yaml = require('js-yaml')
-  ;
+'use strict';
+var async = require('async');
+var restify = require('restify');
+var createWebhookHandler = require('github-webhook-handler');
+var bunyan = require('bunyan');
+var yaml = require('js-yaml');
 
 var GitHubApi = require('github');
 
@@ -16,8 +13,8 @@ var API = require('./api');
  * Create a queue that only processes one task at a time.
  * A task is simply a function that takes a callback when it's done
  */
-var status_update_queue = async.queue(function worker(fn, cb) {
-  fn(cb);
+var statusUpdateQueue = async.queue(function worker(fn, done) {
+  fn(done);
 }, 1);
 
 
@@ -34,19 +31,19 @@ var GithubHandler = function(options) {
 
   // Instantiate a logger instance.
   var log = bunyan.createLogger({name: 'github-handler',
-    level: options.log_level || 'debug',
+    level: options.logLevel || 'debug',
     // src: true,
     serializers: {
       err: bunyan.stdSerializers.err,
-      req: bunyan.stdSerializers.req
-    }
+      req: bunyan.stdSerializers.req,
+    },
   });
-  var options = {
+  var webhookOptions = {
     path: options.githubWebhookPath,
     secret: options.githubWebhookSecret,
   };
 
-  var handler = createWebhookHandler(options);
+  var handler = createWebhookHandler(webhookOptions);
   handler.on('error', this.errorHandler);
   handler.on('pull_request', this.pullRequestHandler);
 
@@ -60,10 +57,10 @@ var GithubHandler = function(options) {
     next();
   });
   this.server.on('after', restify.auditLogger({
-    log: log
+    log: log,
   }));
 
-  this.server.post(options.path, function(req, res, next) {
+  this.server.post(webhookOptions.path, function(req, res, next) {
     handler(req, res, function(error) {
       res.send(400, 'Error processing hook');
       log.error({err: error}, 'Error processing hook');
@@ -71,7 +68,7 @@ var GithubHandler = function(options) {
     });
   });
 
-  var build_status_controller = function(req, res, next) {
+  var buildStatusController = function(req, res, next) {
     var payload = req.body;
 
     if (req.params.context) {
@@ -85,15 +82,16 @@ var GithubHandler = function(options) {
     self.buildStatusUpdateHandler(payload.update, payload.build, function(err, status) {
       if (err) {
         res.send(500, {error: err});
-      } else {
+      }
+      else {
         res.send(status);
       }
       return next();
     });
   };
 
-  this.server.post('/builds/:bid/status/:context', restify.jsonBodyParser(), build_status_controller);
-  this.server.post('/update', restify.jsonBodyParser(), build_status_controller);
+  this.server.post('/builds/:bid/status/:context', restify.jsonBodyParser(), buildStatusController);
+  this.server.post('/update', restify.jsonBodyParser(), buildStatusController);
 
   this.log = log;
 
@@ -101,7 +99,8 @@ var GithubHandler = function(options) {
     url: this.options.api.url,
     token: this.options.api.token,
     log: this.log,
-    handler: this.options,  // {url, [host|hostname], [protocol], [port]}
+    // {url, [host|hostname], [protocol], [port]}
+    handler: this.options,
   });
 
   if (!(this.api instanceof API)) {
@@ -109,42 +108,43 @@ var GithubHandler = function(options) {
   }
 };
 
-/**
- * Starts the server listening on the configured port.
- */
-GithubHandler.prototype.start = function(cb) {
+GithubHandler.prototype.start = function(done) {
   var self = this;
   this.server.listen({port: self.options.port, host: self.options.hostname || '0.0.0.0'}, function() {
     self.log.info('Now listening on', self.server.url);
-    cb && cb();
+    if (done) {
+      return done();
+    }
   });
 };
 
-GithubHandler.prototype.stop = function(cb) {
+GithubHandler.prototype.stop = function(done) {
   var self = this;
   var url = this.server.url;
   this.server.close(function() {
     self.log.info('Stopped', url);
-    cb && cb();
+    if (done) {
+      done();
+    }
   });
 };
 
 /**
  * Build options for GitHub api HTTP requests.
+ *
+ * @param {object} project - A project object.
+ * @return {object} An instantiated and configured Github API object.
  */
 GithubHandler.prototype.getGithubApi = function(project) {
   var github = new GitHubApi({
-    // required
     version: '3.0.0',
-    // optional
-    debug: true,
+    debug: false,
     protocol: 'https',
-    // host: "github.my-GHE-enabled-company.com",
-    // pathPrefix: "/api/v3", // for some GHEs
     timeout: 5000,
     headers: {
-      'user-agent': 'Probo' // GitHub is happy with a unique user agent
-    }
+      // GitHub requires a unique user agent.
+      'user-agent': 'Probo.CI',
+    },
   });
 
   var auth = {type: 'token', token: this.options.githubAPIToken};
@@ -158,23 +158,23 @@ GithubHandler.prototype.getGithubApi = function(project) {
 
 /**
  * Error handler for Github webhooks.
+ *
+ * @param {Error} error - The error that occurred and is being handled.
  */
 GithubHandler.prototype.errorHandler = function(error) {
   this.log.error({err: error}, 'An error occurred.');
 };
 
 
-/**
- * Handler for pull request events.
- */
-GithubHandler.prototype.pullRequestHandler = function(event, cb) {
+GithubHandler.prototype.pullRequestHandler = function(event, done) {
   // enqueue the event to be processed...
   var self = this;
 
   this.log.info('Github Pull request ' + event.payload.pull_request.id + ' received');
 
   var request = {
-    type: 'pull_request', // also in event.event
+    // Also in event.event.
+    type: 'pull_request',
     service: 'github',
     host: undefined,
     branch: event.payload.pull_request.head.ref,
@@ -188,104 +188,107 @@ GithubHandler.prototype.pullRequestHandler = function(event, cb) {
     payload: event.payload,
   };
 
-  /**
-   * build comes back with an embedded .project
-   * not necessary to do anything here, build status updates will come asyncronously
-   */
+  // Build comes back with an embedded .project key.
+  // It's not necessary to do anything here, build status updates will come asyncronously.
   this.processRequest(request, function(error, build) {
     self.log.info({type: request.type, slug: request.slug, err: error}, 'request processed');
-    cb && cb(error, build);
+    if (done) {
+      return done(error, build);
+    }
   });
 };
 
 /**
  * Called when an build status updates
  *
- * update = {
- *  state: "status of build",
- *  description: "",
- *  context: "the context",
- *  target_url: ""
- * }
- *
- * build has an embedded .project too
+ * @param {object} update - The update object.
+ * @param {string} update.state: "status of build",
+ * @param {string} update.description - The text discription of the build state.
+ * @param {string} update.context - The context used to differentiate this update from other services and steps.
+ * @param {string} update.target_url: The url to link to from the status update.
+ * @param {object} build - The full build object.
+ * @param {object} build.project - The embedded project object.
+ * @param {function} done - The callback to be called after the update is performed.
  */
-GithubHandler.prototype.buildStatusUpdateHandler = function(update, build, cb) {
+GithubHandler.prototype.buildStatusUpdateHandler = function(update, build, done) {
   var self = this;
   self.log.info({update: update, build_id: build.id}, 'Got build status update');
 
   var statusInfo = {
-    state: update.state,  // can be one of pending, success, error, or failure.
+    // Can be one of pending, success, error, or failure.
+    state: update.state,
     description: update.description,
     context: update.context,
-    target_url: update.target_url
+    target_url: update.target_url,
   };
 
   var task = this.postStatusToGithub.bind(this, build.project, build.ref, statusInfo);
-  status_update_queue.push(task, function(error) {
+  statusUpdateQueue.push(task, function(error) {
     if (error) {
       self.log.error({err: error, build_id: build.id}, 'An error occurred posting status to GitHub');
-      return cb(error, statusInfo);
+      return done(error, statusInfo);
     }
 
     self.log.info(statusInfo, 'Posted status to Github for', build.project.slug, build.ref);
-    cb(null, statusInfo);
+    done(null, statusInfo);
   });
 };
 
 /**
- * request: {type, service, slug, event}
+ * @param {object} request - The HTTP request to perform.
+ * @param {string} request.type - The type of request to process (eg pull_request).
+ * @param {string} request.service - The service to be checked (always github in this handler).
+ * @param {string} request.slug - The identifier for the repo (repository.full_name from the github api).
+ * @param {string} request.event - The entire event payload from the github api call.
+ * @param {function} done - The callback to call when finished.
  */
-GithubHandler.prototype.processRequest = function(request, cb) {
+GithubHandler.prototype.processRequest = function(request, done) {
   var self = this;
   self.log.info({type: request.type, id: request.id}, 'Processing request');
 
   this.api.findProjectByRepo(request, function(error, project) {
     if (error || !project) {
-      return self.log.info(
-        {err: error},
-        'Project for github repo ' + request.slug + ' not found'
-      );
+      return self.log.info({error}, `Project for github repo ${request.slug} not found`);
     }
 
     self.log.info({project: project}, 'Found project for PR');
 
     self.fetchProboYamlConfigFromGithub(project, request.sha, function(error, config) {
       self.log.info({err: error, config: config}, 'Probo Yaml Config file');
+      var build;
 
       if (error) {
         // If we can't find a yaml file we should error.
-        return self.buildStatusUpdateHandler(
-          { // update
-            state: 'failure',
-            description: error.message,
-            context: 'ProboCI/env',
-          }, { // build
-            ref: request.sha,
-            project: project
-          }, function(err) {
-            cb(err);
-          });
+        build = {
+          ref: request.sha,
+          project: project,
+        };
+        var update = {
+          state: 'failure',
+          description: error.message,
+          context: 'ProboCI/env',
+        };
+        return self.buildStatusUpdateHandler(update, build, done);
       }
 
-      var build = {
+      build = {
         ref: request.sha,
         pullRequest: request.pull_request + '',
         branch: request.branch,
         config: config,
-        request: request
+        request: request,
       };
 
-      self.api.submitBuild(build, project, function(err, submitted_build) {
+      self.api.submitBuild(build, project, function(err, submittedBuild) {
         if (err) {
           // TODO: save the PR if submitting it fails (though logging it here might be ok)
-          self.log.error({err: err, request: request, build: build, response: submitted_build}, 'Problem submitting build');
-          return cb && cb(err);
+          self.log.error({err: err, request: request, build: build, response: submittedBuild}, 'Problem submitting build');
+          return done && done(err);
         }
 
-        self.log.info({build: submitted_build}, 'Submitted build');
+        self.log.info({build: submittedBuild}, 'Submitted build');
 
-        cb(null, submitted_build);
+        done(null, submittedBuild);
       });
 
     });
@@ -296,7 +299,10 @@ GithubHandler.prototype.processRequest = function(request, cb) {
 /**
  * Posts status updates to Github.
  *
- * statusInfo should be the status message to post to GH - see https://developer.github.com/v3/repos/statuses/
+ * @param {object} project - The project object to post the status for.
+ * @param {string} sha - The git commit id that we are posting a status for.
+ * @param {string} statusInfo - This should be the status message to post to GH. See https://developer.github.com/v3/repos/statuses/
+ * @param {function} done - The callback to call when the status has been updated.
  */
 GithubHandler.prototype.postStatusToGithub = function(project, sha, statusInfo, done) {
   var self = this;
@@ -313,24 +319,28 @@ GithubHandler.prototype.postStatusToGithub = function(project, sha, statusInfo, 
 
 /**
  * Fetches configuration from a .probo.yml file in the github repo.
+ *
+ * @param {object} project - The project object.
+ * @param {string} sha - The git commit id to fetch the .probo.yaml from.
+ * @param {function} done - The callback to call upon error/completion.
  */
 GithubHandler.prototype.fetchProboYamlConfigFromGithub = function(project, sha, done) {
   var self = this;
-  var path = '/contents?ref=' + sha;
   var github = this.getGithubApi(project);
 
   github.repos.getContent({user: project.owner, repo: project.repo, ref: sha, path: ''}, function(error, files) {
     if (error) return done(error);
-
     var i = null;
     var regex = /^(.?probo.ya?ml|.?proviso.ya?ml)$/;
     var match = false;
     var file;
     for (i in files) {
-      file = files[i];
-      if (regex.test(file.name)) {
-        match = true;
-        break;
+      if (files[i]) {
+        file = files[i];
+        if (regex.test(file.name)) {
+          match = true;
+          break;
+        }
       }
     }
     if (!match) {
@@ -345,11 +355,13 @@ GithubHandler.prototype.fetchProboYamlConfigFromGithub = function(project, sha, 
         return done(error);
       }
 
-      var content, settings;
+      var content;
+      var settings;
       try {
         content = new Buffer(file.content, 'base64');
         settings = yaml.safeLoad(content.toString('utf8'));
-      } catch (e) {
+      }
+      catch (e) {
         return done(new Error(`Failed to parse ${file.path}:` + e.message));
       }
 

--- a/test/github_handler.js
+++ b/test/github_handler.js
@@ -8,7 +8,6 @@ var nock = require('nock');
 var nockout = require('./__nockout');
 
 var GithubHandler = require('../lib/GithubHandler');
-var nocker = null;
 
 var config = {
   githubWebhookPath: '/ghh',
@@ -50,8 +49,7 @@ describe('webhooks', function() {
     });
 
     afterEach('reset network mocks', function() {
-      // TODO: Why isn't nocker defined here?
-      // nocker.cleanup();
+      nocker.cleanup();
     });
 
     it('is routed', function(done) {
@@ -273,7 +271,7 @@ function initNock() {
   nock.enableNetConnect(ghhServer.server.url.replace('http://', ''));
 
   // Nock out github URLs.
-  nockout('github.json', {
+  return nockout('github.json', {
     not_required: ['status_update'],
     processor: function(nocks) {
       // nock out API URLs
@@ -310,6 +308,4 @@ function initNock() {
       nocks[nocks.length - 1].name = 'status_update';
     },
   });
-
-  return nocker;
 }

--- a/test/github_handler.js
+++ b/test/github_handler.js
@@ -69,7 +69,7 @@ describe('webhooks', function() {
         // TODO: WAT? why isn't this a set of async callbacks so we actually know when it's done?!
         // pause for a little before finishing to allow push processing to run
         // and hit all the GH nocked endpoints
-        setTimeout(done, 100);
+        setTimeout(done, 200);
       });
     });
 


### PR DESCRIPTION
I'm not sure what's breaking the tests exactly, it might have been the addition of `use strict`. Anyway, I have them passing without the `nock.cleanup()` call. Seems like we should run it on general principle but nothing seems to break even when running `mocha -w` with multiple runs.

@zanchin I'd love for you to have a look.

I also tidied up a bunch of coding standards compliance stuff.