### PR TITLE
Setting daemon process titles

### DIFF
--- a/bin/probo
+++ b/bin/probo
@@ -26,10 +26,6 @@ loader.addAndNormalizeObject(process.env);
 
 var commandName = argv._[0];
 
-// Note: The title of a process (on linux) can be changed at any time and the
-// long-running subommands will override this later.
-process.title = 'probo';
-
 probo.cli.loadCommands(function(error, commands) {
   if (error) throw error;
 

--- a/bin/probo
+++ b/bin/probo
@@ -26,6 +26,10 @@ loader.addAndNormalizeObject(process.env);
 
 var commandName = argv._[0];
 
+// Note: The title of a process (on linux) can be changed at any time and the
+// long-running subommands will override this later.
+process.title = 'probo';
+
 probo.cli.loadCommands(function(error, commands) {
   if (error) throw error;
 

--- a/cli-subcommands/container-manager.js
+++ b/cli-subcommands/container-manager.js
@@ -24,6 +24,7 @@ exports.run = function(amour) {
   var Server = amour.ContainerManager;
   var server = new Server();
   var config = amour.config;
+  process.title = 'probo-cm';
   server.configure(config, function(error) {
     if (error) throw error;
     server.run(amour, function(error) {

--- a/cli-subcommands/github-handler.js
+++ b/cli-subcommands/github-handler.js
@@ -37,6 +37,7 @@ exports.configure = function(config) {
 };
 
 exports.run = function(amour) {
+  process.title = 'probo-ghh';
   server.start();
 };
 


### PR DESCRIPTION
This makes it so that running `lsof -i -P`, `ps aux` and similar have the title of the process for context. It has the sad side effect of making so that the latter (`ps aux`) doesn't include the arguments passed in when invoking the command (you won't see the command line args specified at invocation time). I'm betting there's other linux magic that could fill us in but I'm not sure. I find the labels make it a bit easier to correlate things like listening ports/hosts rather than running `ps aux` to get the PID and then isolating the row that I care about.

Thoughts @zanchin?