### PR TITLE
Use dockerode's modem to properly process Docker log streams.

### DIFF
--- a/lib/container_manager/task_runner.js
+++ b/lib/container_manager/task_runner.js
@@ -38,16 +38,11 @@ module.exports = function* runTasks(tasks, opts) {
 
         log.debug(`${task.name} (${task.buildCommand()}) OUTPUT`);
 
-        // little hack to get rid of the first 8 bytes of every chunk coming out of exec
-        // TODO: figure out why it's really happening
-        result.stream = result.stream.pipe(through2(function(chunk, enc, cb) {
-          // This is a cheap pointer manipulation operation.
-          cb(null, chunk.slice(8));
-        }));
-
         // send output to external logger
         if (opts.loom) {
-          result.stream
+          var outputStream = through2();
+          task.container.container.modem.demuxStream(result.stream, outputStream, outputStream);
+          outputStream
             .pipe(opts.loom.createLogStream({
               task: {id: task.id, name: task.name, plugin: task.plugin},
               buildId: task.container.build.id,

--- a/lib/plugins/TaskRunner/AbstractPlugin.js
+++ b/lib/plugins/TaskRunner/AbstractPlugin.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var Promise = require('bluebird');
 var events = require('events');
+var Promise = require('bluebird');
 var util = require('util');
 var intformat = require('biguint-format');
 var FlakeId = require('flake-idgen');


### PR DESCRIPTION
Docker [uses control characters](https://github.com/apocas/docker-modem/blob/master/lib/modem.js#L263) to multiplex stdout and stderr into a single byte stream. We have an unreliable hack trying to separate them, this removes the hack and uses [docker-modem](http://npmjs.org/package/docker-modem) instead.

I wanted to move this down into the AbstractTask but unfortunately performing the same operation there are returning the through2 outputStream wasn't working and I didn't want to lose anymore time to troubleshooting it as I'm refactoring that code in the `build-class` branch anyway.  This should fix it temporarily.