### PR TITLE
Loom auth with API tokens support

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -64,6 +64,7 @@ api:
 # loom (log aggregator server)
 loom:
   url: "http://localhost:3060"
+  token: "API token here"
 
 # asset server (must NOT be localhost because it's called from within container)
 assets:

--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -109,7 +109,7 @@ Server.prototype.configure = function(config, done) {
   // Allow the db to be handed in with the config.
   this.db = config.levelupDB || level(config.dataDir, {valueEncoding: 'json'});
 
-  this.loom = loom({url: config.loom.url}, this.log);
+  this.loom = loom(config.loom, this.log);
 
   // update safeco's error handler with bunyan logging one
   co = co(function(err, opts) {

--- a/lib/loom.js
+++ b/lib/loom.js
@@ -7,6 +7,7 @@ var url = require('url');
  * Create a loom client
  * @param {Object} config - Loom configuration - url
  * @param {Object} config.url - Loom url of server
+ * @param {Object} config.token - API token for loom
  * @param {Logger} [log] - Bunyan logger instance
  * @return {object} - The loom client.
  */
@@ -48,15 +49,23 @@ function createClient(config, log) {
         opts.id = require('querystring').escape(opts.id);
       }
 
+      /* eslint-disable quote-props, lines-around-comment */
+      var headers = {
+        connection: 'keep-alive',
+        'x-stream-metadata': JSON.stringify(metadata),
+      };
+      /* eslint-enable quote-props, lines-around-comment */
+
+      if (config.token) {
+        headers.authorization = `Bearer ${config.token}`;
+      }
+
       var loom = http.request({
         hostname: url.parse(config.url).hostname,
         port: url.parse(config.url).port,
         method: 'post',
         path: '/stream' + (opts.id ? `/${opts.id}` : '') + (opts.force ? '?force=true' : ''),
-        headers: {
-          'connection': 'keep-alive',
-          'x-stream-metadata': JSON.stringify(metadata),
-        },
+        headers: headers,
       }, loomHandler);
 
       // disable connection timeout: let the output flow for as long as it wants


### PR DESCRIPTION
Default config for loom is to have auth disabled. So proper deployment order is to upgrade CM with Loom's auth config before or at the same time as enabling auth on the loom service.

Related PRs:
https://github.com/ProboCI/probo-web/pull/31
https://github.com/ProboCI/loom/pull/3
https://github.com/ProboCI/probo/pull/31
https://github.com/ProboCI/probo-puppet-master/pull/24