### PR TITLE
Drupal plugin - allow an arbitrary snippet to be appended to settings.php

### DIFF
--- a/lib/plugins/TaskRunner/Drupal.js
+++ b/lib/plugins/TaskRunner/Drupal.js
@@ -1,4 +1,5 @@
 'use strict';
+var shellEscape = require('shell-escape');
 
 module.exports = class Drupal extends require('./Script') {
 
@@ -19,6 +20,7 @@ module.exports = class Drupal extends require('./Script') {
    *   @param {string} options.profileName - The profileName, used in symlinking this directory if makeFile is specified and used to select the profile to install if `runInstall` is selected.
    *   @param {string} options.installArgs - A set of params to concat onto the drush `site-install` command (defaults to '').
    *   @param {string} options.subDirectory - The directory of the actual web root (defaults to 'docroot').
+   *   @param {string} [options.settingsAppend] - A snippet to append to the end of the settings.php file.
    *   @param {string} [options.settingsRequireFile] - A file to require at the end of settings.php (in order to get around not
    *      checking settings.php into your repo).
    */
@@ -131,6 +133,10 @@ module.exports = class Drupal extends require('./Script') {
     ]);
     if (this.options.settingsRequireFile) {
       let command = 'echo "require_once(\'' + this.options.settingsRequireFile + '\');" >> /var/www/html/sites/' + this.options.siteFolder + '/settings.php';
+      this.script.push(command);
+    }
+    if (this.options.settingsAppend) {
+      let command = 'echo ' + shellEscape([this.options.settingsAppend]) + ' >> /var/www/html/sites/' + this.options.siteFolder + '/settings.php';
       this.script.push(command);
     }
   }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "request": "^2.53.0",
     "request-promise": "^1.0.2",
     "restify": "^2.8.5",
+    "shell-escape": "^0.2.0",
     "stream-combiner": "^0.2.2",
     "superagent": "^1.1.0",
     "through2": "^0.6.3",


### PR DESCRIPTION
This should provide for a bunch of different use cases. The shell-escape module is used to escape whatever junk they might throw at us and should ensure that lands in the settings.php. I tested using a bunch of multiline stuff using a pipe operator like so:

```` yaml
steps:
  - name: Provision Drupal
    plugin: Drupal
    runInstall: standard
    settingsRequireFile: 'site-settings.php'
    settingsAppend: |
      $bar = 'baz';
      $foo = 'stuff';

````