### PR TITLE
Switch the Bitbucket Downloader to use a supported mechanism for specifying the access token

### DIFF
--- a/lib/plugins/TaskRunner/BitbucketDownloader.js
+++ b/lib/plugins/TaskRunner/BitbucketDownloader.js
@@ -84,13 +84,13 @@ module.exports = class BitbucketDownloader extends require('./Script') {
 
   setBitbucketScript() {
     var params = this.params;
-    var auth = `x-token-auth:${params.token}`;
-    var url = `https://${auth}@bitbucket.org/${params.owner}/${params.repo}/get/${params.ref}.${params.format}`;
+    var auth = `--header 'Authorization:Bearer ${params.token}'`;
+    var url = `https://bitbucket.org/${params.owner}/${params.repo}/get/${params.ref}.${params.format}`;
 
     var script = [
       'mkdir -p $SRC_DIR',
       'cd $SRC_DIR',
-      `wget -q -O - "${url}" | tar xzf - --strip-components=1`,
+      `wget -q -O - ${auth} "${url}" | tar xzf - --strip-components=1`,
     ];
 
     this.setScript(script);

--- a/test/tasks/BitbucketDownloader.js
+++ b/test/tasks/BitbucketDownloader.js
@@ -1,0 +1,46 @@
+'use strict';
+var BitbucketDownloader = require('../../lib/plugins/TaskRunner/BitbucketDownloader');
+
+var mockContainer = {
+  log: {
+    child: function() {
+      return {
+        debug: function() {},
+        error: function() {},
+      };
+    },
+  },
+};
+
+describe('BitbucketDownloader', function() {
+  it('builds proper task configuration', function() {
+    var build = {
+      commit: {
+        ref: 'master',
+      },
+    };
+    var project = {
+      provider: {type: 'bitbucket'},
+      owner: 'owner',
+      repo: 'repo',
+      service_auth: {
+        token: 'access_token',
+      },
+    };
+    var gc = new BitbucketDownloader(mockContainer, {build, project});
+
+    gc.setBitbucketScript();
+
+    gc.script.should.eql(`unset HISTFILE
+export PS4='\$ '
+set -x
+mkdir -p $SRC_DIR; cd $SRC_DIR
+mkdir -p $SRC_DIR
+cd $SRC_DIR
+wget -q -O - --header 'Authorization:Bearer access_token' "https://bitbucket.org/owner/repo/get/master.tar.gz" | tar xzf - --strip-components=1
+`);
+
+    gc.description().should.eql('BitbucketDownloader owner/repo @ master');
+  });
+});
+


### PR DESCRIPTION
Our original method of using the access token was silently deprecated by Bitbucket on 2016-02-05. Research revealed that they now only support the `Bearer access_token` header method.

Also added a test for the generated BB Downloader script.