### PR TITLE
Allow the interface that the container manager binds on to be configurable

### DIFF
--- a/cli-subcommands/container-manager.js
+++ b/cli-subcommands/container-manager.js
@@ -15,6 +15,8 @@ exports.options = function(yargs) {
   return yargs
     .describe('port', 'The port to listen on.')
     .alias('port', 'p')
+    .describe('host', 'The host to listen on.')
+    .alias('host', 'h')
     .describe('data-dir', 'The directory to store data in via leveldb.')
     .alias('data-dir', 'd')
   ;

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -3,7 +3,7 @@ name: amour
 # Port for the server to listen on
 port: 3010
 # The host time bind to.
-bind: '0.0.0.0'
+host: '0.0.0.0'
 hostname: localhost
 # Can be any { socketPath: '/path' } or { host: 'somehost', port: 9999 }
 # See dockerode constructor for details: https://github.com/apocas/dockerode

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -2,6 +2,8 @@
 name: amour
 # Port for the server to listen on
 port: 3010
+# The host time bind to.
+bind: '0.0.0.0'
 hostname: localhost
 # Can be any { socketPath: '/path' } or { host: 'somehost', port: 9999 }
 # See dockerode constructor for details: https://github.com/apocas/dockerode

--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -54,7 +54,7 @@ var Server = function() {
 
 Server.prototype.run = function(probo, done) {
   var self = this;
-  this.server.listen(probo.config.port, probo.config.bind, function(error) {
+  this.server.listen(probo.config.port, probo.config.host, function(error) {
     self.log.info('server started and listening on ' + self.server.url);
     done(error);
   });

--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -54,7 +54,7 @@ var Server = function() {
 
 Server.prototype.run = function(probo, done) {
   var self = this;
-  this.server.listen(probo.config.port, function(error) {
+  this.server.listen(probo.config.port, probo.config.bind, function(error) {
     self.log.info('server started and listening on ' + self.server.url);
     done(error);
   });


### PR DESCRIPTION
Many of our services support this and a lot of them call the option `host`.  I think that's vague and that `bind` is more specific - I think we should standardize on bind everywhere - starting here.