### PR TITLE
Update Script options

### DIFF
--- a/lib/plugins/TaskRunner/Script.js
+++ b/lib/plugins/TaskRunner/Script.js
@@ -35,7 +35,7 @@ module.exports = class Script extends require('./AbstractPlugin') {
       // Set command echo prefix to '$' from a default of '+'.
       'export PS4=\'\$ \'',
       // Enables command echoing.
-      'set -x',
+      'set -uex',
       // Default CWD to $SRC_DIR (create it if it it doesn't exist).
       'mkdir -p $SRC_DIR; cd $SRC_DIR',
     ].concat(script);


### PR DESCRIPTION
In addition to setting `-x` for printing commands we should also set `u` to bail on undefined variables, and `-e` to bail on non-zero steps. I think this should be closer to the "*right thing™*" in most cases.

See [bash documentation](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html) for more detail but:

- `-u` bails on undefined
- `-e` bails on non-zero
- `-x` prints the commands it runs back out