### PR TITLE
Send Github a clear message when a docker image is not found

### DIFF
--- a/lib/Container.js
+++ b/lib/Container.js
@@ -337,6 +337,10 @@ Container.prototype.getDiskUsage = Promise.promisify(function(done) {
  * @return {object} - The command info on what is to be run.
  */
 Container.prototype.buildCommandInfo = function(image) {
+  if (!image) {
+    throw new Error('Use a real `image` in your .probo.yaml file');
+  }
+
   var command = ['penelope'];
   var exposedPorts = {};
   var portBindings = {};


### PR DESCRIPTION
This PR simply enhances the error message sent back to Github if a referenced image is not found.