### PR TITLE
Drupal plugin: Make the Drupal8 config sync directory configurable

### DIFF
--- a/lib/plugins/TaskRunner/Drupal.js
+++ b/lib/plugins/TaskRunner/Drupal.js
@@ -24,6 +24,7 @@ class Drupal extends LAMPApp {
    *   @param {string} options.profileName - The profileName, used in symlinking this directory if makeFile is specified and used to select the profile to install if `runInstall` is selected.
    *   @param {string} options.installArgs - A set of params to concat onto the drush `site-install` command (defaults to '').
    *   @param {string} options.subDirectory - The directory of the actual web root (defaults to 'docroot').
+   *   @param {string} options.configSyncDirectory - The config sync directory used in Drupal 8.
    *   @param {string} [options.settingsAppend] - A snippet to append to the end of the settings.php file.
    *   @param {string} [options.settingsRequireFile] - A file to require at the end of settings.php (in order to get around not
    *      checking settings.php into your repo).
@@ -137,6 +138,7 @@ class Drupal extends LAMPApp {
     const hash = crypto.createHash('sha256');
     hash.update(crypto.randomBytes(40));
     const random = hash.digest('base64');
+    const configSyncDirectory = this.options.configSyncDirectory || `sites/default/files/config_${random}/sync`;
     this.script = this.script.concat([
       `PHP_SNIPPET=$(cat <<END_HEREDOC`,
       `\\$databases = array(`,
@@ -155,7 +157,7 @@ class Drupal extends LAMPApp {
       `  ),`,
       `);`,
       `\\$settings['hash_salt'] = '${random}';`,
-      `\\$config_directories['sync'] = 'sites/default/files/config_${random}/sync';`,
+      `\\$config_directories['sync'] = '${configSyncDirectory}';`,
       `END_HEREDOC`,
       `)`,
       `if [ ! -e "/var/www/html/sites/${this.options.siteFolder}/settings.php" ] ; then`,


### PR DESCRIPTION
Currently it is possible to override the config sync directory using a `settingsAppend` but this is going to be such a common Drupal 8 case that I think we should make this available as a top level config parameter.

To test: run a build without specifying the directory via `options. configSyncDirectory` and check the result in settings.php then run another build with it set.