### PR TITLE
Drupal fra before updb

### DIFF
--- a/lib/plugins/TaskRunner/Drupal.js
+++ b/lib/plugins/TaskRunner/Drupal.js
@@ -88,11 +88,11 @@ class Drupal extends LAMPApp {
     if (this.options.runInstall) {
       this.addScriptRunInstall();
     }
-    if (this.options.databaseUpdates) {
-      this.addScriptDatabaseUpdates();
-    }
     if (this.options.revertFeatures) {
       this.addScriptRevertFeatures();
+    }
+    if (this.options.databaseUpdates) {
+      this.addScriptDatabaseUpdates();
     }
     if (this.options.clearCaches) {
       this.addScriptClearCaches();


### PR DESCRIPTION
This PR reverses the order of the db update and features revert so features can be manipulated.

The current order of operations is drush updb before drush fra. This doesn't allow us to make db changes to feature elements (view blocks created by the feature, for instance, which is my specific reason for this PR). There is no advantage that I can see to the current order - if you're using drush updb to install a feature after drush fra, it will be synced with code anyway.
