### PR TITLE
Wait as long as needed for MySQL to start.

### DIFF
--- a/lib/plugins/TaskRunner/LAMPApp.js
+++ b/lib/plugins/TaskRunner/LAMPApp.js
@@ -70,7 +70,7 @@ class LAMPApp extends Script {
 
   addScriptHeader() {
     this.script = this.script.concat([
-      'sleep 3',
+      'READY=0; while ! `nc -z 127.0.0.1 3306` && [ $READY -lt 60 ]; do echo "Waiting for MySQL..."; READY=$((READY + 1)); sleep 1; done; if `nc -z 127.0.0.1 3306`; then echo "MySQL is ready."; else echo "MySQL failed to start!"; exit 1; fi;',
     ]);
   }
 


### PR DESCRIPTION
This resloves an issue in which, under high server load, MySQL server
takes a long time to start up. In these cases, builds hand forever
because the default behavior was to wait for a set period of time and
then begin running build steps. Often in these cases the build would
fail for lack of a MySQL connection. Instead, we can use netcat and hold
us in a loop until netcat is able to reach MySQL on the standard port,
only then allowing the build steps to continue.

### To Test
 - Restart probo and trigger a build as normal.
 - Note that you should not see any sleep output initially.
 - Otherwise things should look the same as before.
 - If you want to do a more extensive test:
  - Change the port number to an alternate port that has no service listening on it.
  - Kick off a build.
  - In a terminal window, enter the container of the new build
  - Start the service on the specified port or create a small node.js hello world server to listen on that port (actually netcat can do that too `nc -l 127.0.0.1 [PORT]`)
  - Ensure that the build continues from this point on.