### PR TITLE
Remove `-e` from bash args for build plugins to allow bash runs to continue if something fails

### DIFF
--- a/lib/plugins/TaskRunner/Script.js
+++ b/lib/plugins/TaskRunner/Script.js
@@ -35,7 +35,7 @@ module.exports = class Script extends require('./AbstractPlugin') {
       // Set command echo prefix to '$' from a default of '+'.
       'export PS4=\'\$ \'',
       // Enables command echoing.
-      'set -uex',
+      'set -ux',
       // Default CWD to $SRC_DIR (create it if it it doesn't exist).
       'mkdir -p $SRC_DIR; cd $SRC_DIR',
     ].concat(script);


### PR DESCRIPTION
## Problem

Lots of users are running phantomjs or selenium on our infrastructure and there's no good way to do that, run your tests, and kill it again.
## Solution

Just don't run bash with `-e` which exits on the first non-zero exit code.  This makes us less like jenkins and means the rest of your script will still try to run after you hit the end but 
## To test

If you create a job with the following without this PR you'll never see the second echo - with it you should see both echos:

``` yaml
steps:
  - name: Testing
    script: |
      true
      echo "That exited $?"
      false
      echo "That exited $?"
```
