### PR TITLE
Feature/lol/reaper messages

### DIFF
--- a/bin/probo
+++ b/bin/probo
@@ -1,13 +1,14 @@
 #! /usr/bin/env node
-var path = require('path'),
-    util = require('util'),
-    fs = require('fs');
+'use strict';
+
+var path = require('path');
+var util = require('util');
 
 var Loader = require('yaml-config-loader');
 var yargs = require('yargs');
 var loader = new Loader();
 
-loader.on('error', function(error){
+loader.on('error', function(error) {
   if (error.name === 'YAMLException') {
     console.error(util.print('Error parsing YAML file `', error.filePath, '`:', error.reason));
     console.log(error);
@@ -56,7 +57,7 @@ probo.cli.loadCommands(function(error, commands) {
     var setOptions = {};
     var key = null;
     for (key in yargs.argv) {
-      if (yargs.argv[key] != undefined) {
+      if (yargs.argv[key] !== undefined) {
         setOptions[key] = yargs.argv[key];
       }
     }

--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -497,8 +497,8 @@ Server.prototype.routes.del['containers/:id'] = function(req, res, next) {
 
   function handleError(err, msg) {
     msg = msg ? msg + ': ' : '';
-    var message = msg + (err.json || err.message);
-    var code = err.statusCode || 500;
+    let message = msg + (err.json || err.message);
+    let code = err.statusCode || 500;
     res.send(code, {error: message.trim(), code: code});
     next();
   }
@@ -509,7 +509,7 @@ Server.prototype.routes.del['containers/:id'] = function(req, res, next) {
     }
 
     // name is: probo--[repo slug]--[project id]--[buildid]
-    var buildId = info.Name.split('--')[3];
+    let buildId = info.Name.split('--')[3];
 
     if (!buildId) {
       err = new Error(`BuildId not found for container name ${info.Name}`);
@@ -528,8 +528,9 @@ Server.prototype.routes.del['containers/:id'] = function(req, res, next) {
       container.build = build;
 
       container.remove({force: req.query.force, v: req.query.v}, function(err, data) {
-        if (err) return handleError(err);
-
+        if (err) {
+          return handleError(err);
+        }
         self.log.info({build}, 'Got build object to update');
 
         self.updateBuildContainerStatus(build, function(err, build) {

--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -25,6 +25,7 @@ var eventbus = require('probo-eventbus');
 Promise.longStackTraces();
 
 const SETUP_CONTEXT = 'env';
+const REAPED_EVENT = 'reaped';
 
 var logContainerEvents = function(container) {
   container.on('stateChange', function(event, err, data) {
@@ -484,11 +485,17 @@ Server.prototype.routes.get.containers = function(req, res, next) {
  * @param {object} res - Restify response object.
  * @param {Function} next - The next middleware to call.
  */
-Server.prototype.routes.del['containers/:id'] = function(req, res, next) {
-  var self = this;
+Server.prototype.routes.del['containers/:id/'] = function(req, res, next) {
+  this.deleteContainer(req, res, next);
+};
+
+
+Server.prototype.deleteContainer = function(req, res, next) {
+  let self = this;
+  let reason = req.query.reason || 0;
 
   // delete/remove the container and update the build entry in the DB
-  var container = new Container({
+  let container = new Container({
     docker: this.config.docker,
     containerId: req.params.id,
     log: this.log,
@@ -517,6 +524,13 @@ Server.prototype.routes.del['containers/:id'] = function(req, res, next) {
       return handleError(err);
     }
 
+    // Reason must be a non-negative integer.
+    if (parseFloat(reason) != parseInt(reason) || isNaN(reason) || reason < 0) {
+      err = new Error('Invalid reason');
+      err.statusCode = 500;
+      return handleError(err);
+    }
+
     // find matching build object
     self.getBuildData(buildId, function(err, build) {
       if (err) {
@@ -542,9 +556,10 @@ Server.prototype.routes.del['containers/:id'] = function(req, res, next) {
 
           // set the reaped flag to true to help upstream event processors have more context
           build.reaped = true;
+          build.reapedReason = reason;
 
           self.storeBuildData(build, function(err) {
-            emitBuildEvent(build, 'reaped', {}, {log: self.log, producer: self.buildsEventProducer});
+            emitBuildEvent(build, REAPED_EVENT, {}, {log: self.log, producer: self.buildsEventProducer});
 
             res.json({status: 'removed', id: info.Id});
             return next();


### PR DESCRIPTION
See https://github.com/ProboCI/probo-coordinator/pull/87
and 
https://github.com/ProboCI/probo-reaper/pull/8

The delete endpoint now will populate a reason code and send this along as part of the event bus build data. When saving this `reapedReason` will also be saved.

### To test
 - Use a curl request to delete a build (`curl -X DELETE containermanagerURL/containerId?force=true&reason=2`)
 - Check level db to ensure this build has the reaped reason on it.