### PR TITLE
Exclude special characters from config dir name.

### DIFF
--- a/lib/plugins/TaskRunner/Drupal.js
+++ b/lib/plugins/TaskRunner/Drupal.js
@@ -138,7 +138,7 @@ class Drupal extends LAMPApp {
   addD8PHPSettings() {
     const hash = crypto.createHash('sha256');
     hash.update(crypto.randomBytes(40));
-    const random = hash.digest('base64');
+    const random = hash.digest('base64').toString().replace(/[^a-zA-Z0-9]/ig, '');
     const configSyncDirectory = this.options.configSyncDirectory || `sites/default/files/config_${random}/sync`;
     this.script = this.script.concat([
       `PHP_SNIPPET=$(cat <<END_HEREDOC`,


### PR DESCRIPTION
The random string we used for the name of the config sync
directory should be purely alphanumeric. Special characters
such as slashes (allowed in base64) can cause problems
as Drupal will think it is a nested directory.