### PR TITLE
Create pin/unpin endpoints.

### DIFF
--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -825,6 +825,31 @@ Server.prototype.routes.del['builds/:id'] = function(req, res, next) {
   });
 };
 
+Server.prototype.routes.put['builds/:id/pin'] = function(req, res, next) {
+  this.setPinnedStatus(req, res, true, next);
+};
+
+Server.prototype.routes.put['builds/:id/unpin'] = function(req, res, next) {
+  this.setPinnedStatus(req, res, false, next);
+};
+
+Server.prototype.setPinnedStatus = function(req, res, status, next) {
+  let self = this;
+  this.getFromDB('builds', req.params.id, function(error, build) {
+    if (error) {
+      return res.send(404, error);
+    }
+    build.pinned = status;
+    self.storeBuildData(build, function(error) {
+      if (error) {
+        next(error);
+        return;
+      }
+      emitBuildEvent(build, 'updated', {}, {log: self.log, producer: self.buildsEventProducer});
+      res.send(build);
+    });
+  });
+};
 
 Server.prototype.resetContainerIdleTimeout = function(container, set, log) {
   var idleTimeout = this.config.containerIdleTimeout || '10m';


### PR DESCRIPTION
Related to https://github.com/ProboCI/probo-coordinator/pull/88
Related to https://github.com/ProboCI/probo-reaper/pull/9

This change allows put requests to be made for builds which will
set them to pinned or unpinned. Updating a build result in the
new status for the build being stored in the db (level) and also
will result in a build event being sent. The reaper can capture
this build event as needed.

### Testing
- See https://github.com/ProboCI/probo-coordinator/pull/88