### PR TITLE
Add steps and status to builds

### DIFF
--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -292,9 +292,9 @@ Server.prototype.runBuild = function* (build, log) {
         let match = false;
         for (let i in build.steps) {
           if (build.steps[i].id === task.id) {
+            // We don't currently act on timeouts, suppress their output until its meaningful.
+            delete localTask.timeout;
             build.steps[i] = localTask;
-            // TODO: This isn't reliable, variable setup step number.
-            localTask.config = build.config.steps[i + 1];
             match = true;
             break;
           }

--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -28,7 +28,7 @@ const SETUP_CONTEXT = 'env';
 
 var logContainerEvents = function(container) {
   container.on('stateChange', function(event, err, data) {
-    container.log.debug({event, err, data, build: container.build}, `container event ${container.containerId}: '${event}', err:${err ? err.json.trim() : false}`);
+    container.log.debug({err, buildId: container.build.id}, `container event ${container.containerId}: '${event}', err:${err ? err.json.trim() : false}`);
   });
 };
 
@@ -167,7 +167,7 @@ Server.prototype.configure = function(config, done) {
         server.log.error({err: error}, `Failed to activate build stream producer: ${error.message}`);
       }
 
-      self.buildsEventProducer = producer;
+      self.buildEventsProducer = producer;
       done(error);
     });
   }
@@ -191,7 +191,8 @@ Server.prototype.routes.post['start-build'] = function(req, res, next) {
   var build = body.build;
   var project = body.project;
 
-  req.log.debug(body, 'Starting Build');
+  req.log.trace(body);
+  req.log.debug('Starting Build');
 
   req.buildId = build.id;
   build.project = project;
@@ -258,7 +259,7 @@ Server.prototype.runBuild = function* (build, log) {
     log: log,
   };
 
-  log.debug({build, containerConfig: _.merge(containerConfig, {log: {}})}, `Starting container build: ${containerName}`);
+  log.trace({build, containerConfig: _.merge(containerConfig, {log: {}})});
   log.info(`Starting container build: ${containerName}`);
 
   // attach logger
@@ -271,7 +272,7 @@ Server.prototype.runBuild = function* (build, log) {
   var setupTasks = yield container.buildSetupTasks();
   var userTasks = yield container.buildUserTasks();
 
-  var updateStatus = function* (context, status) {
+  var updateStatus = function* (context, status, task) {
     try {
       // prefix context with ProboCI namespace
       var instance = self.config.instanceName || 'ProboCI';
@@ -279,11 +280,42 @@ Server.prototype.runBuild = function* (build, log) {
 
       let processedStatus = yield self.api.setBuildStatusAsync(build, context, status);
 
-      // TODO: we can add this for completeness, but it's probably not really necessary and could be confusing upstream
-      // build.statuses[context] = processedStatus;
+      // TODO: This approximates the data structure that will cleanly be published by the build_class branch once that is merged.
+      if (!build.status) {
+        build.status = 'running';
+      }
+      if (task && task.id) {
+        build.steps = build.steps ? build.steps : [];
+        let localTask = task.toJSON();
+        localTask.status = status.status;
+        localTask.description = status.description;
+        let match = false;
+        for (let i in build.steps) {
+          if (build.steps[i].id === task.id) {
+            build.steps[i] = localTask;
+            // TODO: This isn't reliable, variable setup step number.
+            localTask.config = build.config.steps[i + 1];
+            match = true;
+            break;
+          }
+        }
+        if (match === false) {
+          build.steps.push(localTask);
+        }
+        for (let item of build.steps) {
+          log.error('LOGGING RESULT CODE: ' + parseInt(item.result.code).toString(), item);
+          if (item && item.result && item.result.code &&  item.result.code !== 0) {
+            build.status = 'failed';
+          }
+        }
+      }
+      else {
+        log.error({task}, 'ID-less task');
+      }
 
+      self.storeBuildData(build);
       // emit a status update event on the container so the status update gets logged and sent to the event stream
-      emitBuildEvent(build, 'status updated', {context, status: processedStatus}, {log, producer: self.buildsEventProducer});
+      emitBuildEvent(build, 'status updated', {context, status: processedStatus}, {log, producer: self.buildEventsProducer});
 
       log.info({status: _.pick(status, 'state', 'description')}, 'status updated');
     }
@@ -293,29 +325,29 @@ Server.prototype.runBuild = function* (build, log) {
   };
 
   // handle status updates for setup task
-  var taskUpdater = function(context, status) {
+  var taskUpdater = function(task, context, status) {
     // ignore context, it'll always be SETUP_CONTEXT
     // and for self-updates, action will always be 'running'
     // and state is 'pending' beause "env" status isn't complete
     // until we're ready to run user steps
     status.action = 'running';
     status.state = 'pending';
-    co(updateStatus(SETUP_CONTEXT, status));
+    co(updateStatus(SETUP_CONTEXT, status, task));
   };
   for (let task of setupTasks) {
-    task.on('update', taskUpdater);
+    task.on('update', taskUpdater.bind(this, task));
   }
 
   // handle status updates for each task
-  taskUpdater = function(context, status) {
-    co(updateStatus(context, status));
+  taskUpdater = function(task, context, status) {
+    co(updateStatus(context, status, task));
   };
   for (let task of userTasks) {
-    task.on('update', taskUpdater);
+    task.on('update', taskUpdater.bind(this, task));
   }
 
 
-  emitBuildEvent(build, 'started', {}, {log, producer: self.buildsEventProducer});
+  emitBuildEvent(build, 'started', {}, {log, producer: self.buildEventsProducer});
 
   // continue processing the build in the background and firing off events
   setImmediate(function() {
@@ -325,7 +357,7 @@ Server.prototype.runBuild = function* (build, log) {
         yield* updateStatus(SETUP_CONTEXT, {state: 'pending', action: 'running', description: `The hamsters are working hard on your setup`});
         // returns output of container.inspect
         let containerStatus = yield container.create();
-        log.info({status: containerStatus}, 'Container ready');
+        log.info(`Container ready ${containerStatus.id}`, {id: containerStatus.Id, status: containerStatus.Status});
 
         yield* updateStatus(SETUP_CONTEXT, {state: 'pending', action: 'running', description: 'Environment built'});
       }
@@ -392,7 +424,11 @@ Server.prototype.runBuild = function* (build, log) {
 
         yield self.storeBuildDataAsync(build);
 
-        emitBuildEvent(build, 'ready', {}, {log, producer: self.buildsEventProducer});
+        if (build.status === 'running') {
+          build.status = 'successful';
+        }
+        self.storeBuildData(build);
+        emitBuildEvent(build, 'ready', {}, {log, producer: self.buildEventsProducer});
       }
       catch (error) {
         log.error({err: error}, 'Failed to write build to the BD');
@@ -543,7 +579,7 @@ Server.prototype.routes.del['containers/:id'] = function(req, res, next) {
           build.reaped = true;
 
           self.storeBuildData(build, function(err) {
-            emitBuildEvent(build, 'reaped', {}, {log: self.log, producer: self.buildsEventProducer});
+            emitBuildEvent(build, 'reaped', {}, {log: self.log, producer: self.buildEventsProducer});
 
             res.json({status: 'removed', id: info.Id});
             return next();
@@ -931,7 +967,9 @@ Server.prototype.storeInDB = function(key, data, done) {
     data.id = format(this.flakeIdGen.next(), 'hex');
   }
   this.db.put(key + '!' + data.id, data, function(error) {
-    done(error, data);
+    if (done) {
+      done(error, data);
+    }
   });
 };
 

--- a/lib/plugins/TaskRunner/AbstractPlugin.js
+++ b/lib/plugins/TaskRunner/AbstractPlugin.js
@@ -36,6 +36,7 @@ var AbstractPlugin = function(container, options) {
 
   this.run = Promise.promisify(this.run.bind(this));
   this.log = this.container.log.child({component: `${this.plugin} [${this.name}]`});
+  this.updateStatus = this.updateStatus.bind(this);
 
   events.EventEmitter.call(this);
 };


### PR DESCRIPTION
So this change adds the state of the build and the steps of the build as an array top level properties of the build object. The step configuration, state, exit code, and status are all stored on the step in the array in a way consistent with the data model that we will have when we eventually merge in the build_class branch.

This is necessary for the probo-notifier to send meaningful notifications with sufficient context.