### PR TITLE
Allow builds to optionally be accessible to the proxy while building

### DIFF
--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -87,6 +87,9 @@ Server.prototype.configure = function(config, done) {
   this.config = config;
   // TODO: We should probably be injecting this logger.
   this.log = logger.getLogger('container-manager');
+  if (config.logLevel) {
+    this.log._level = config.logLevel;
+  }
 
   var API = require('./api');
 

--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -27,6 +27,11 @@ Promise.longStackTraces();
 const SETUP_CONTEXT = 'env';
 const REAPED_EVENT = 'reaped';
 
+const BUILD_STATUS_RUNNING = 'running';
+const BUILD_STATUS_FAILED = 'failed';
+const BUILD_STATUS_SUCCESSFUL = 'successful';
+const BUILD_STATUS_TIMEOUT = 'timeout';
+
 var logContainerEvents = function(container) {
   container.on('stateChange', function(event, err, data) {
     container.log.debug({err, buildId: container.build.id}, `container event ${container.containerId}: '${event}', err:${err ? err.json.trim() : false}`);
@@ -283,7 +288,7 @@ Server.prototype.runBuild = function* (build, log) {
 
       // TODO: This approximates the data structure that will cleanly be published by the build_class branch once that is merged.
       if (!build.status) {
-        build.status = 'running';
+        build.status = BUILD_STATUS_RUNNING;
       }
       if (task && task.id) {
         build.steps = build.steps ? build.steps : [];
@@ -305,7 +310,7 @@ Server.prototype.runBuild = function* (build, log) {
         }
         for (let item of build.steps) {
           if (item && item.result && item.result.code && item.result.code !== 0) {
-            build.status = 'failed';
+            build.status = BUILD_STATUS_FAILED;
           }
         }
       }
@@ -357,6 +362,12 @@ Server.prototype.runBuild = function* (build, log) {
         yield* updateStatus(SETUP_CONTEXT, {state: 'pending', action: 'running', description: `The hamsters are working hard on your setup`});
         // returns output of container.inspect
         let containerStatus = yield container.create();
+        // Save the container information for the build.
+        build.container = {
+          id: container.container.id,
+          name: containerName,
+        };
+        self.storeBuildData(build);
         log.info(`Container ready ${containerStatus.id}`, {id: containerStatus.Id, status: containerStatus.Status});
 
         yield* updateStatus(SETUP_CONTEXT, {state: 'pending', action: 'running', description: 'Environment built'});
@@ -424,8 +435,8 @@ Server.prototype.runBuild = function* (build, log) {
 
         yield self.storeBuildDataAsync(build);
 
-        if (build.status === 'running') {
-          build.status = 'successful';
+        if (build.status === BUILD_STATUS_RUNNING) {
+          build.status = BUILD_STATUS_SUCCESSFUL;
         }
         self.storeBuildData(build);
         emitBuildEvent(build, 'ready', {}, {log, producer: self.buildEventsProducer});
@@ -645,10 +656,13 @@ Server.prototype.routes.post['container/proxy'] = function(req, res, next) {
     }
 
     // lookup container object for the build
-    if (!build.container) {
-      res.setHeader('content-type', 'application/json');
-      res.send(423, {buildId, errorCode: '423P', message: 'Build is still in progress'});
-      return next();
+    // TODO: We should have an explicit status for if the build is in progress.
+    if (build.status === BUILD_STATUS_RUNNING) {
+      if (!build.config || !build.config.allowAccessWhileBuilding) {
+        res.setHeader('content-type', 'application/json');
+        res.send(423, {buildId, errorCode: '423P', message: 'Build is still in progress'});
+        return next();
+      }
     }
 
     if (build.reaped) {
@@ -986,6 +1000,7 @@ Server.prototype.getBuildData = function(buildId, done) {
 };
 
 Server.prototype.storeBuildData = function(data, done) {
+  done = done || function() {};
   data.updatedAt = new Date().toJSON();
   return this.storeInDB('builds', data, done);
 };

--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -171,10 +171,10 @@ Server.prototype.configure = function(config, done) {
   // configure event streaming system for builds
   try {
     new eventbus.plugins[config.buildsEventStream.plugin].Producer(config.buildsEventStream.config, function(error, producer) {
-      console.log('connected to eventbus.');
       if (error) {
         server.log.error({err: error}, `Failed to activate build stream producer: ${error.message}`);
       }
+      server.log.info('Connected to eventbus');
 
       self.buildEventsProducer = producer;
       done(error);

--- a/test/lib/containerManager.js
+++ b/test/lib/containerManager.js
@@ -6,8 +6,8 @@ var should = require('should');
 var level = require('level');
 
 var Loader = require('yaml-config-loader');
-var CM = require('../../lib/ContainerManager');
-var server = new CM();
+var ContainerManager = require('../../lib/ContainerManager');
+var server = new ContainerManager();
 var loader = new Loader();
 var db = level('/tmp/db', {db: require('memdown')});
 
@@ -46,7 +46,8 @@ describe('Server', function() {
       config.api.token = 'testToken';
 
       db.put(`builds!${reapedBuildId}`, JSON.stringify({container: true, reaped: true}));
-      db.put(`builds!${pendingBuildId}`, JSON.stringify({container: false, reaped: false}));
+      db.put(`builds!${pendingBuildId}`, JSON.stringify({container: false, reaped: false, status: 'running'}));
+      config.logLevel = Number.POSITIVE_INFINITY;
       server.configure(config, function(err) {
         if (err) {
           return done(err);


### PR DESCRIPTION
Some users have requested external HTTP access to their builds while the build was still in progress so that they could trigger accessibility compliance and visual diffing tools.

To test this pull request create a PR in a repo with the following .yaml file and try to visit the site while it in the time it is building or the 60 seconds it is sleeping.  You can get the build id from the dashboard or by watching the logs. Go to e.g [build-id].local.probo.build.

``` yaml
steps:
  - name: Sleep and setup a docroot
    plugin: Script
    script: |
      mkdir -p /var/www/html
      echo '<h1>This is a build</h1>' > /var/www/html/index.html
      chmod 777 -R /var/www
      sleep 60
```

Next add this `allowAccessWhileBuilding: true` and attempt the same:

``` yaml
allowAccessWhileBuilding: true
steps:
  - name: Sleep and setup a docroot
    plugin: Script
    script: |
      mkdir -p /var/www/html
      echo '<h1>This is a build</h1>' > /var/www/html/index.html
      chmod 777 -R /var/www
      sleep 60
```

Now you should see progress even before the build finishes.