### PR TITLE
Conditionally include the build link as an environment variable

### DIFF
--- a/lib/Container.js
+++ b/lib/Container.js
@@ -190,13 +190,15 @@ Container.prototype.create = Promise.promisify(function(done) {
     Env: [
       `COMMIT_REF=${this.build.commit.ref}`,
       `BUILD_ID=${this.build.id}`,
-      `BUILD_DOMAIN=${this.build.links.build}`,
       `SRC_DIR=${SRC_DIR}`,
       `ASSET_DIR=${ASSET_DIR}`,
       `PWD=${SRC_DIR}`,
       `PROBO_ENVIRONMENT=TRUE`,
     ],
   };
+  if (this.build.links && this.build.links.build) {
+    createOptions.Env.push(`BUILD_DOMAIN=${this.build.links.build}`);
+  }
   var startOptions = {
     PortBindings: commandInfo.portBindings,
     Binds: self.binds,


### PR DESCRIPTION
In the SaaS version of probo we have a service sitting between the github handler and the container manager that validates and decorates the build requests with membership data and we currently have this component adding the build links to the build object. This means that builds are currently broken in the open source edition.

This doesn't seem like the cleanest way to tackle this issue but it's a stopgap that fixes the OSS setup for now.