### PR TITLE
Support HTTP Basic Access Authentication

### DIFF
--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -693,8 +693,8 @@ Server.prototype.routes.post['container/proxy'] = function(req, res, next) {
             yield self.storeBuildDataAsync(build);
           }
           catch (e) {
-            log.error({err: e, event: event, build: {id: build.id}},
-                      'Failed to update container status for build');
+            let message = 'Failed to update container status for build';
+            log.error({err: e, event: event, buildId: build.id}, message);
           }
         });
       }
@@ -755,12 +755,12 @@ Server.prototype.routes.post['container/proxy'] = function(req, res, next) {
       // If host is set, port isn't used in .format().
       delete urlParts.host;
       urlParts.port = exposedHostPort;
-
-      res.json({
+      let proxyData = {
         proxy: {
           host: urlParts.hostname,
           port: urlParts.port,
           url: url.format(urlParts),
+          basicAuth: build.config.basicAuth || null,
         },
         buildConfig: build.config,
         status: {
@@ -768,7 +768,8 @@ Server.prototype.routes.post['container/proxy'] = function(req, res, next) {
           info: up ? 'ok' : `Timed out after ${duration}ms`,
           ts: new Date(),
         },
-      });
+      };
+      res.json(proxyData);
       return next();
     }
     catch (e) {


### PR DESCRIPTION
Users have requested (#79) an easy way to add http basic auth to their builds. In the past we have coached them to set this up with apache .htaccess files but this makes the process a bit more seamless.

To test, add the following to your .probo.yaml file at the top level of the yaml file, run a build, and try to view it - you should be prompted for a username and password:

``` yaml
 basicAuth:
   username: foo
   password: bar
```

_Please note: This is useless without ProboCI/probo-proxy#9 but can be deployed independently._
