### PR TITLE
Add a separate route to delete both a build and its container

### DIFF
--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -30,7 +30,7 @@ const REAPED_EVENT = 'reaped';
 const BUILD_STATUS_RUNNING = 'running';
 const BUILD_STATUS_FAILED = 'failed';
 const BUILD_STATUS_SUCCESSFUL = 'successful';
-const BUILD_STATUS_TIMEOUT = 'timeout';
+// const BUILD_STATUS_TIMEOUT = 'timeout';
 
 var logContainerEvents = function(container) {
   container.on('stateChange', function(event, err, data) {
@@ -900,7 +900,7 @@ Server.prototype.routes.post['builds/:id'] = function(req, res, next) {
  * @param {object} res - Restify response object.
  * @param {Function} next - The next middleware to call.
  */
-Server.prototype.routes.del['builds/:id/container'] = function(req, res, next) {
+Server.prototype.routes.del['builds/:id'] = function(req, res, next) {
   var self = this;
   self.getBuildData(req.params.id, function(err, build) {
     if (err) {
@@ -910,26 +910,10 @@ Server.prototype.routes.del['builds/:id/container'] = function(req, res, next) {
 
     self.log.info({buildId: build.id, containerId: build.container.id}, 'Deleteing build and its container');
 
-    // override the id param in the request
-    // so that the container delete route
-    // can work as written
+    // overwrite the id param in the request
+    // and send request to container delete method
     req.params.id = build.container.id;
     self.deleteContainer(req, res, next);
-  });
-};
-
-/**
- * Delete an individual build from the DB
- * @param {object} req - Restify request object.
- * @param {object} res - Restify response object.
- * @param {Function} next - The next middleware to call.
- */
-Server.prototype.routes.del['builds/:id'] = function(req, res, next) {
-  this.log.info('deleting build ' + req.params.id);
-  this.delFromDB('builds', req.params.id, function(error) {
-    if (error) return res.send(500, error);
-    res.send('success');
-    next();
   });
 };
 

--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -894,6 +894,31 @@ Server.prototype.routes.post['builds/:id'] = function(req, res, next) {
 };
 
 /**
+ * Delete an individual build and its container
+ *
+ * @param {object} req - Restify request object.
+ * @param {object} res - Restify response object.
+ * @param {Function} next - The next middleware to call.
+ */
+Server.prototype.routes.del['builds/:id/container'] = function(req, res, next) {
+  var self = this;
+  self.getBuildData(req.params.id, function(err, build) {
+    if (err) {
+      self.log.error({buildId: req.params.id}, `Problem getting build data: ${err.message}`);
+      return next(err);
+    }
+
+    self.log.info({buildId: build.id, containerId: build.container.id}, 'Deleteing build and its container');
+
+    // override the id param in the request
+    // so that the container delete route
+    // can work as written
+    req.params.id = build.container.id;
+    self.deleteContainer(req, res, next);
+  });
+};
+
+/**
  * Delete an individual build from the DB
  * @param {object} req - Restify request object.
  * @param {object} res - Restify response object.


### PR DESCRIPTION
This PR creates a route at `builds/:id/container` that fully deletes the specified build and its container. This PR isn't dependent on anything itself, so you can probably curl requests to see it work.

The new route works by wrapping around `containers/:id`. The new route is created here in the instance when other connecting systems are aware of the build ids but not the container ids.