### PR TITLE
Allow stash code downloads to be disabled

### DIFF
--- a/lib/plugins/TaskRunner/StashDownloader.js
+++ b/lib/plugins/TaskRunner/StashDownloader.js
@@ -108,11 +108,18 @@ module.exports = class StashDownloader extends require('./Script') {
   }
 
   setStashScript() {
-    var params = this.params;
-    var script = [
+    let params = this.params;
+    let build = this.build;
+    // Stash is self hosted and invariably some organizations will use
+    // self-signed certificates. This is a semi-valid use case. Ideally
+    // these clients would just get a letsencrypt certificate but some
+    // IT orgs don't trust them yet. This feature lets those orgs
+    // specify that we should not try to validate the cert chain.
+    let insecureFlag = build.config.insecureStashDownload ? '--no-check-certificate' : '';
+    let script = [
       'mkdir -p $SRC_DIR',
       'cd $SRC_DIR',
-      `wget -q -O - --header 'Authorization:${params.auth}' "${params.url}" | tar xzf - `,
+      `wget -q -O - ${insecureFlag} --header 'Authorization:${params.auth}' "${params.url}" | tar xzf - `,
     ];
     this.setScript(script);
   }


### PR DESCRIPTION
 Stash is self hosted and invariably some organizations will use self-signed certificates. This is a semi-valid use case. Ideally these clients would just get a letsencrypt certificate but some IT orgs don't trust them yet. This feature lets those orgs specify that we should not try to validate the cert chain.