### PR TITLE
Fix wordpress plugin tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "4.0"
   - "4.1"
 script:
+  - npm test
   - npm run coverage
 after_script:
   - ./node_modules/.bin/coveralls < ./coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 # Run this faster because it can run on container based infra.
 language: node_js
 node_js:
-  - "iojs"
-  - "4.0"
   - "4.1"
+  - "4.4"
 script:
   - npm test
   - npm run coverage

--- a/lib/Container.js
+++ b/lib/Container.js
@@ -237,6 +237,9 @@ Container.prototype.findOrCreate = function() {
 
 /**
  * Returns the current status of the container
+ *
+ * @param {function} done - the callback function, if provided
+ * @return {function} - container inspect funnction, callback or promise
  */
 Container.prototype.getState = function(done) {
   return this.inspect()
@@ -301,7 +304,11 @@ Container.prototype.remove = Promise.promisify(function(opts, done) {
 });
 
 /**
- * Get the particular exposed port from container info.
+ * Retrieve container info getter.
+ *
+ * @param {object} data - container info data
+ * @param {number} port - port number used on container
+ * @return {function} - function to get container info
  */
 Container.prototype.getExposedPortFromContainerInfo = function(data, port) {
   try {
@@ -314,13 +321,16 @@ Container.prototype.getExposedPortFromContainerInfo = function(data, port) {
 
 /**
  * Gets the disk usage of the container.
- * Current implementation requires the AUFS Storage driver and to be run as root.
+ * Current implementation requires the AUFS
+ * Storage driver and to be run as root.
  * Errors if there's no root access or not using the AUFS driver
  *
- * @param {Function} done - callback that takes err and an object as arguments. The object has {virtualBytes, realBytes}, for the size of the inderlying image and container layer respectively
+ * @param {Function} done - callback that takes err and an object as
+ *  arguments. The object has {virtualBytes, realBytes}, for the
+ *  size of the inderlying image and container layer respectively.
  */
 Container.prototype.getDiskUsage = Promise.promisify(function(done) {
-  var result = {realBytes: undefined, virtualBytes: undefined};
+  var result = {realBytes: null, virtualBytes: null};
 
   // stat the container to ensure that it's using the AUFS driver
   this.container.inspect({size: true}, function(err, info) {

--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -262,7 +262,7 @@ Server.prototype.runBuild = function* (build, log) {
   };
 
   log.trace({build, containerConfig: _.merge(containerConfig, {log: {}})});
-  log.info(`Starting container build: ${containerName}`);
+  log.info({container: containerName, config: containerConfig}, `Starting container build`);
 
   // attach logger
   containerConfig.log = log;
@@ -314,7 +314,7 @@ Server.prototype.runBuild = function* (build, log) {
         }
       }
       else {
-        log.error({task}, 'ID-less task');
+        log.warn({task}, 'ID-less task');
       }
 
       self.storeBuildData(build);

--- a/lib/plugins/TaskRunner/WordPressApp.js
+++ b/lib/plugins/TaskRunner/WordPressApp.js
@@ -40,11 +40,11 @@ class WordPressApp extends LAMPApp {
 
     this.options.siteFolder = options.siteFolder || 'default';
     this.options.profileName = options.profileName || 'standard';
-    this.options.flushCaches = !!options.flushCaches || true;
+    this.options.flushCaches = (options.flushCaches === true);
     // Allow backwards compatibility to old settings.
     this.options.wpHome = options.wpHome || options.devHome || null;
     this.options.wpDomain = options.wpDomain || options.devDomain || null;
-    this.options.updatePlugins = !!options.updatePlugins || false;
+    this.options.updatePlugins = (options.updatePlugins === true);
     // TODO: Add some kind of validation.
 
     // Filter out secret strings

--- a/lib/plugins/TaskRunner/WordPressApp.js
+++ b/lib/plugins/TaskRunner/WordPressApp.js
@@ -40,11 +40,11 @@ class WordPressApp extends LAMPApp {
 
     this.options.siteFolder = options.siteFolder || 'default';
     this.options.profileName = options.profileName || 'standard';
-    this.options.flushCaches = (options.flushCaches === true);
+    this.options.flushCaches = String(options.flushCaches).toLowerCase() === 'true';
     // Allow backwards compatibility to old settings.
     this.options.wpHome = options.wpHome || options.devHome || null;
     this.options.wpDomain = options.wpDomain || options.devDomain || null;
-    this.options.updatePlugins = (options.updatePlugins === true);
+    this.options.updatePlugins = String(options.updatePlugins).toLowerCase() === 'true';
     // TODO: Add some kind of validation.
 
     // Filter out secret strings

--- a/lib/plugins/TaskRunner/WordPressApp.js
+++ b/lib/plugins/TaskRunner/WordPressApp.js
@@ -40,7 +40,7 @@ class WordPressApp extends LAMPApp {
 
     this.options.siteFolder = options.siteFolder || 'default';
     this.options.profileName = options.profileName || 'standard';
-    this.options.flushCaches = String(options.flushCaches).toLowerCase() === 'true';
+    this.options.flushCaches = String(options.flushCaches) !== 'undefined' ? String(options.flushCaches).toLowerCase() === 'true' : true;
     // Allow backwards compatibility to old settings.
     this.options.wpHome = options.wpHome || options.devHome || null;
     this.options.wpDomain = options.wpDomain || options.devDomain || null;

--- a/lib/plugins/TaskRunner/WordPressApp.js
+++ b/lib/plugins/TaskRunner/WordPressApp.js
@@ -120,8 +120,8 @@ class WordPressApp extends LAMPApp {
 
   addScriptReplaceDomain() {
     // flatten home page url first, so that it points to probo root
-    this.script.push(this.replaceOption('$BUILD_DOMAIN', 'home'));
-    this.script.push(this.replaceOption('$BUILD_DOMAIN', 'siteurl'));
+    this.script.push(this.replaceOption('home', '$BUILD_DOMAIN'));
+    this.script.push(this.replaceOption('siteurl', '$BUILD_DOMAIN'));
 
     if (this.options.wpHome) {
       this.script.push(`export WP_HOME=${this.options.wpHome}`);
@@ -136,12 +136,12 @@ class WordPressApp extends LAMPApp {
 
   /**
    * Use wp-cli to replace an option.
+   * @param {string} orig - The original option value to replace.
    * @param {string} updated - The new value for the option.
-   * @param {string} option - The option to replace.
    * @return {string} - The wp-cli command.
    */
-  replaceOption(updated, option) {
-    var command = `cd /var/www/html/ ; wp option update ${option} ${updated} --allow-root`;
+  replaceOption(orig, updated) {
+    var command = `cd /var/www/html/ ; wp option update ${orig} ${updated} --allow-root`;
     return command;
   }
 

--- a/package.json
+++ b/package.json
@@ -4,26 +4,23 @@
   "description": "The main repository for the probo project.",
   "homepage": "http://probo.ci",
   "main": "index.js",
-  "repository": "https://github.com/ProboCI/probo.git",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProboCI/probo.git"
+  },
   "scripts": {
     "cm": "nodemon ./bin/probo container-manager -c cm.yml",
     "ghh": "nodemon ./bin/probo github-handler -c ghh.yml",
     "test": "mocha --recursive --require should",
-    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha",
+    "coverage": "istanbul cover ./node_modules/.bin/_mocha",
     "watch": "mocha -w --recursive --require should",
-    "standards": "./node_modules/.bin/eslint lib cli-subcommands test"
+    "standards": "eslint lib cli-subcommands test"
   },
   "contributors": [
-    {
-      "name": "Howard Tyson",
-      "email": "howard@howardtyson.com",
-      "url": "http://howardtyson.com"
-    },
-    {
-      "name": "Ilya Braude",
-      "email": "ilya@ilyabraude.com",
-      "url": "http://www.ilyabraude.com/"
-    }
+    "Howard Tyson <howard@howardtyson.com> (http://howardtyson.com)",
+    "Ilya Braude <ilya@ilyabraude.com> (http://www.ilyabraude.com/)",
+    "Laurence Liss <laurence@probo.ci> (https://www.laurenceliss.com)",
+    "James Cole <mail@ofjamescole.com> (https://ofjamescole.com)"
   ],
   "license": "Apache-2.0",
   "dependencies": {
@@ -78,5 +75,12 @@
     "shell-quote": "^1.4.3",
     "should": "^5.2.0",
     "sinon": "^1.16.1"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/ProboCI/probo/issues"
+  },
+  "directories": {
+    "test": "test"
+  },
+  "author": "Probo.CI <info@probo.ci> (https://probo.ci)"
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "cm": "nodemon ./bin/probo container-manager -c cm.yml",
     "ghh": "nodemon ./bin/probo github-handler -c ghh.yml",
     "test": "mocha --recursive --require should",
-    "coverage": "istanbul cover ./node_modules/.bin/_mocha",
+    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha",
     "watch": "mocha -w --recursive --require should",
-    "standards": "eslint lib cli-subcommands test"
+    "standards": "./node_modules/.bin/eslint lib cli-subcommands test"
   },
   "contributors": [
     "Howard Tyson <howard@howardtyson.com> (http://howardtyson.com)",

--- a/test/tasks/Wordpress.js
+++ b/test/tasks/Wordpress.js
@@ -24,8 +24,6 @@ describe('WordPress plugin', function() {
       database: 'my-cool-db.sql',
       wpDomain: 'http://example.com',
       wpHome: 'http://example.com/home',
-      updatePlugins: false,
-      flushCaches: true,
     };
 
     options2 = {
@@ -62,7 +60,7 @@ describe('WordPress plugin', function() {
     app.should.have.property('options').which.is.a.Object;
     app.options.should.have.property('siteFolder').which.eql('default');
     app.options.should.have.property('profileName').which.eql('standard');
-    app.options.should.have.property('flushCaches').which.eql(options.flushCaches);
+    app.options.should.have.property('flushCaches').which.eql(true);
     app.options.should.have.property('wpHome').which.eql(options.wpHome);
     app.options.should.have.property('wpDomain').which.eql(options.wpDomain);
     app.options.should.have.property('updatePlugins').which.eql(false);

--- a/test/tasks/Wordpress.js
+++ b/test/tasks/Wordpress.js
@@ -11,53 +11,176 @@ var mockContainer = {
   },
 };
 
+/* eslint-disable no-unused-expressions */
 
-describe('WordPress App', function() {
+describe('WordPress plugin', function() {
+  var options;
+  var app;
+  var options2;
+  var app2;
 
-  var options = {
-    database: 'my-cool-db.sql',
-    devDomain: 'http://example.com',
-    devHome: 'http://example.com/home',
-  };
-  var app = new WordPressApp(mockContainer, options);
+  before(function(done) {
+    options = {
+      database: 'my-cool-db.sql',
+      wpDomain: 'http://example.com',
+      wpHome: 'http://example.com/home',
+      updatePlugins: false,
+      flushCaches: true,
+    };
 
-  var options2 = {
-    database: 'my-cool-db.sql',
-    devDomain: 'http://example.com',
-    devHome: 'http://example.com/home',
-    databaseGzipped: true,
-    flushCaches: false,
-  };
-  var app2 = new WordPressApp(mockContainer, options2);
+    options2 = {
+      database: 'my-cool-db.sql',
+      wpDomain: 'http://example2.com',
+      wpHome: 'http://example.com/home',
+      updatePlugins: true,
+      databaseGzipped: true,
+      flushCaches: false,
+    };
 
-  it('builds proper lamp script', function() {
+    done();
+  });
+
+  beforeEach(function(done) {
+    app = new WordPressApp(mockContainer, options);
+    app.should.be.ok;
+    app.should.have.property('id').which.is.a.String;
+    app.id.should.match(/[0-9a-z]{16}/g);
+
+    app2 = new WordPressApp(mockContainer, options2);
+    app2.should.be.ok;
+    app2.should.have.property('id').which.is.a.String;
+    app2.id.should.match(/[0-9a-z]{16}/g);
+
+    done();
+  });
+
+  it('should correctly instantiate', function(done) {
+    var appDescription = app.description();
+    appDescription.should.be.a.String.which.eql('WordPressApp \'Provisioning WordPress!\'');
+
+    app.should.have.property('databaseName').which.eql(constants.WORDPRESS_DATABASE_NAME);
+    app.should.have.property('options').which.is.a.Object;
+    app.options.should.have.property('siteFolder').which.eql('default');
+    app.options.should.have.property('profileName').which.eql('standard');
+    app.options.should.have.property('flushCaches').which.eql(options.flushCaches);
+    app.options.should.have.property('wpHome').which.eql(options.wpHome);
+    app.options.should.have.property('wpDomain').which.eql(options.wpDomain);
+    app.options.should.have.property('updatePlugins').which.eql(false);
+    app.options.should.have.property('secrets').which.is.a.Array;
+    app.options.secrets.should.have.length(0);
+    app.should.have.property('subDirectory').which.eql('docroot');
+    app.should.have.property('script').which.is.a.String;
+
+    done();
+  });
+
+  it('should correctly build a command to replace WP options', function(done) {
+    var replaceCommand = app.replaceOption('old', 'new');
+    replaceCommand.should.be.a.String.which.eql('cd /var/www/html/ ; wp option update old new --allow-root');
+
+    done();
+  });
+
+  it('should correctly build a command to search and replace database text', function(done) {
+    var replaceCommand = app.replaceTextDb('old', 'new');
+    replaceCommand.should.be.a.String.which.eql('cd /var/www/html/ ; wp search-replace \'old\' \'new\' --skip-columns=guid --allow-root');
+
+    done();
+  });
+
+  it('should correctly build up the script', function(done) {
+    app.script = [];
+    app.addScriptAppendWPConfigSettings();
+    app.script.should.have.length(10);
+    app.script.should.eql([
+      'if [ ! -a "/var/www/html/wp-config.php" ] ; then',
+      '  echo "<?php\ndefine(\'DB_NAME\', \'database_name_here\');\ndefine(\'DB_USER\', \'username_here\');\ndefine(\'DB_PASSWORD\', \'password_here\');\ndefine(\'DB_HOST\', \'localhost\');\ndefine(\'DB_CHARSET\', \'utf8\');\ndefine(\'DB_COLLATE\', \'\');\ndefine(\'AUTH_KEY\',         \'put your unique phrase here\');\ndefine(\'SECURE_AUTH_KEY\',  \'put your unique phrase here\');\ndefine(\'LOGGED_IN_KEY\',    \'put your unique phrase here\');\ndefine(\'NONCE_KEY\',        \'put your unique phrase here\');\ndefine(\'AUTH_SALT\',        \'put your unique phrase here\');\ndefine(\'SECURE_AUTH_SALT\', \'put your unique phrase here\');\ndefine(\'LOGGED_IN_SALT\',   \'put your unique phrase here\');\ndefine(\'NONCE_SALT\',       \'put your unique phrase here\');\n\\$table_prefix = \'wp_\';\ndefine(\'WP_DEBUG\', false);\nif ( !defined(\'ABSPATH\') )\n\tdefine(\'ABSPATH\', dirname(__FILE__) . \'/\');\nrequire_once(ABSPATH . \'wp-settings.php\');\n" > /var/www/html/wp-config.php',
+      'fi',
+      'sed -i "1i <?php require(\'probo-config.php\'); ?>" /var/www/html/wp-config.php',
+      'echo "<?php',
+      'define(\'DB_NAME\', \'wordpress\');',
+      'define(\'DB_USER\', \'root\');',
+      'define(\'DB_PASSWORD\', \'strongpassword\');',
+      'define(\'DB_HOST\', \'localhost\');',
+      '?>" >> /var/www/html/probo-config.php;',
+    ]);
+
+    app.script = [];
+    app.addScriptUpdatePlugins();
+    app.script.should.have.length(1);
+    app.script.should.eql(['cd /var/www/html/ ; wp plugin update --all --allow-root']);
+
+    app.script = [];
+    app.addScriptFlushCaches();
+    app.script.should.have.length(1);
+    app.script.should.eql(['cd /var/www/html/ ; wp cache flush --allow-root']);
+
+    app.script = [];
+    app.addScriptFixFilePerms();
+    app.script.should.have.length(3);
+    app.script.should.eql([
+      'mkdir -p /var/www/html/wp-content/uploads',
+      'chown www-data:www-data /var/www/html/wp-content/uploads',
+      'chmod 755 /var/www/html/wp-content/uploads',
+    ]);
+
+    app.script = [];
+    app.addScriptReplaceDomain();
+    app.script.should.have.length(6);
+    app.script.should.eql([
+      'cd /var/www/html/ ; wp option update home $BUILD_DOMAIN --allow-root',
+      'cd /var/www/html/ ; wp option update siteurl $BUILD_DOMAIN --allow-root',
+      'export WP_HOME=http://example.com/home',
+      'cd /var/www/html/ ; wp search-replace \'$WP_HOME\' \'$BUILD_DOMAIN\' --skip-columns=guid --allow-root',
+      'export WP_DOMAIN=http://example.com',
+      'cd /var/www/html/ ; wp search-replace \'$WP_DOMAIN\' \'$BUILD_DOMAIN\' --skip-columns=guid --allow-root',
+    ]);
+
+    app.script = [];
+    app.populateScriptArray();
+    app.script.should.have.length(35);
+
+    done();
+  });
+
+  it('builds proper lamp script', function(done) {
     app.script.should.containEql('mkdir -p $SRC_DIR; cd $SRC_DIR');
     app.script.should.containEql('if [ -d "$SRC_DIR/docroot" ]');
     app.script.should.containEql('if [ -a "$SRC_DIR/index.php" ]');
     app.script.should.containEql('ln -s $SRC_DIR  /var/www/html');
     app.script.should.containEql(`mysql -e 'create database ${constants.WORDPRESS_DATABASE_NAME}'`);
+
+    done();
   });
 
-  it('handles gzipped databases', function() {
+  it('handles gzipped databases', function(done) {
     app2.script.should.containEql('gunzip -c');
+
+    done();
   });
 
-  it('inserts the snippet into wp-config.php', function() {
+  it('inserts the snippet into wp-config.php', function(done) {
     app.script.should.containEql('sed -i "1i <?php require(\'probo-config.php\'); ?>" /var/www/html/wp-config.php');
     app.script.should.containEql(`define('DB_PASSWORD', '${constants.DATABASE_PASSWORD}');`);
+
+    done();
   });
 
-  it('switches to the probo domain', function() {
-    app.script.should.containEql('export DEV_HOME=http://example.com/home');
-    app.script.should.containEql('export DEV_DOMAIN=http://example.com');
+  it('switches to the probo domain', function(done) {
+    app.script.should.containEql('export WP_HOME=http://example.com/home');
+    app.script.should.containEql('export WP_DOMAIN=http://example.com');
     app.script.should.containEql('wp option update home $BUILD_DOMAIN');
-    app.script.should.containEql('wp search-replace \'$DEV_HOME\' \'$BUILD_DOMAIN\'');
+    app.script.should.containEql('wp search-replace \'$WP_HOME\' \'$BUILD_DOMAIN\'');
     app.script.should.containEql('wp option update siteurl $BUILD_DOMAIN');
-    app.script.should.containEql('wp search-replace \'$DEV_DOMAIN\' \'$BUILD_DOMAIN\'');
+    app.script.should.containEql('wp search-replace \'$WP_DOMAIN\' \'$BUILD_DOMAIN\'');
+
+    done();
   });
 
-  it('flushes the cache', function() {
+  it('flushes the cache', function(done) {
     app.script.should.containEql('wp cache flush');
     app2.script.should.not.containEql('wp cache flush');
+
+    done();
   });
 });


### PR DESCRIPTION
This is just some cleanup of the Wordpress plugin. I added more tests to cover the plugin more thoroughly too. 
 
1. I fixed two bugs. Before this PR, the [flushCaches](https://github.com/ProboCI/probo/pull/95/files#diff-290329cbdb7390784f1b4e9bbd81125dR43) option could never be false. Also, the [Container.prototype.inspect](https://github.com/ProboCI/probo/pull/95/files#diff-599aa5690d4bc1ef4f297bfe52690761R259) method needs to be fully runnable as a promise. The AbstractPlugin calls this without `done` defined, and before this PR that causes an error.
1. Also, I fixed some small linting errors to get this passing code standards.
1. Lastly, I updated the WP plugin tests to make them pass. The last round of updates to it broke the tests.