### PR TITLE
Add reaped reason and date to build object before storing it

### DIFF
--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -542,7 +542,7 @@ Server.prototype.routes.del['containers/:id/'] = function(req, res, next) {
 Server.prototype.deleteContainer = function(req, res, next) {
   let self = this;
   let reason = req.query.reason || 0;
-  let reasonText = (req.query.reasonText) ? decodeURIComponent(req.query.reasonText) : 'The build was deleted for an unknown reason.';
+  let reasonText = (req.query.reasonText) ? decodeURIComponent(req.query.reasonText) : 'This build was deleted for an unknown reason.';
   let reapedDate = req.query.reapedDate || Date.now();
 
   // delete/remove the container and update the build entry in the DB

--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -542,6 +542,8 @@ Server.prototype.routes.del['containers/:id/'] = function(req, res, next) {
 Server.prototype.deleteContainer = function(req, res, next) {
   let self = this;
   let reason = req.query.reason || 0;
+  let reasonText = (req.query.reasonText) ? decodeURIComponent(req.query.reasonText) : 'The build was deleted for an unknown reason.';
+  let reapedDate = req.query.reapedDate || Date.now();
 
   // delete/remove the container and update the build entry in the DB
   let container = new Container({
@@ -606,6 +608,8 @@ Server.prototype.deleteContainer = function(req, res, next) {
           // set the reaped flag to true to help upstream event processors have more context
           build.reaped = true;
           build.reapedReason = reason;
+          build.reapedReasonText = reasonText;
+          build.reapedDate = reapedDate;
 
           self.storeBuildData(build, function(err) {
             emitBuildEvent(build, REAPED_EVENT, {}, {log: self.log, producer: self.buildEventsProducer});


### PR DESCRIPTION
This PR collects the reaped reason and date from query parameters sent to it via the `deleteContainer` method. They are collected here so they are properly stored in the local database, and then sent over the event stream to other systems.