### PR TITLE
Add a 'running' status; Use globally defined status constants.

### DIFF
--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -21,16 +21,9 @@ var logger = require('./logger');
 var runTasks = require('./container_manager/task_runner');
 var loom = require('./loom');
 var eventbus = require('probo-eventbus');
+var constants = require('./constants');
 
 Promise.longStackTraces();
-
-const SETUP_CONTEXT = 'env';
-const REAPED_EVENT = 'reaped';
-
-const BUILD_STATUS_RUNNING = 'running';
-const BUILD_STATUS_FAILED = 'failed';
-const BUILD_STATUS_SUCCESSFUL = 'successful';
-// const BUILD_STATUS_TIMEOUT = 'timeout';
 
 var logContainerEvents = function(container) {
   container.on('stateChange', function(event, err, data) {
@@ -289,20 +282,23 @@ Server.prototype.runBuild = function* (build, log) {
 
       let processedStatus = yield self.api.setBuildStatusAsync(build, context, status);
 
-      // TODO: This approximates the data structure that will cleanly be published by the build_class branch once that is merged.
+      // TODO: This approximates the data structure that will
+      // cleanly be published by the build_class branch once that is merged.
       if (!build.status) {
-        build.status = BUILD_STATUS_RUNNING;
+        build.status = constants.STATUS_RUNNING;
       }
+
       if (task && task.id) {
         build.steps = build.steps ? build.steps : [];
         let localTask = task.toJSON();
-        localTask.status = status.status;
+        // We don't currently act on timeouts,
+        // suppress their output until its meaningful.
+        delete localTask.timeout;
+        localTask.state = status.state;
         localTask.description = status.description;
         let match = false;
         for (let i in build.steps) {
           if (build.steps[i].id === task.id) {
-            // We don't currently act on timeouts, suppress their output until its meaningful.
-            delete localTask.timeout;
             build.steps[i] = localTask;
             match = true;
             break;
@@ -313,7 +309,7 @@ Server.prototype.runBuild = function* (build, log) {
         }
         for (let item of build.steps) {
           if (item && item.result && item.result.code && item.result.code !== 0) {
-            build.status = BUILD_STATUS_FAILED;
+            build.status = constants.STATUS_FAIL;
           }
         }
       }
@@ -322,7 +318,8 @@ Server.prototype.runBuild = function* (build, log) {
       }
 
       self.storeBuildData(build);
-      // emit a status update event on the container so the status update gets logged and sent to the event stream
+      // emit a status update event on the container
+      // so the status update gets logged and sent to the event stream
       emitBuildEvent(build, 'status updated', {context, status: processedStatus}, {log, producer: self.buildEventsProducer});
 
       log.info({status: _.pick(status, 'state', 'description')}, 'status updated');
@@ -336,11 +333,8 @@ Server.prototype.runBuild = function* (build, log) {
   var taskUpdater = function(task, context, status) {
     // ignore context, it'll always be SETUP_CONTEXT
     // and for self-updates, action will always be 'running'
-    // and state is 'pending' beause "env" status isn't complete
-    // until we're ready to run user steps
-    status.action = 'running';
-    status.state = 'pending';
-    co(updateStatus(SETUP_CONTEXT, status, task));
+    status.action = constants.ACTION_RUNNING;
+    co(updateStatus(constants.CONTEXT_SETUP, status, task));
   };
   for (let task of setupTasks) {
     task.on('update', taskUpdater.bind(this, task));
@@ -354,7 +348,6 @@ Server.prototype.runBuild = function* (build, log) {
     task.on('update', taskUpdater.bind(this, task));
   }
 
-
   emitBuildEvent(build, 'started', {}, {log, producer: self.buildEventsProducer});
 
   // continue processing the build in the background and firing off events
@@ -362,7 +355,7 @@ Server.prototype.runBuild = function* (build, log) {
     co(function* () {
       // RUN INITIALIZATION STEPS
       try {
-        yield* updateStatus(SETUP_CONTEXT, {state: 'pending', action: 'running', description: `The hamsters are working hard on your setup`});
+        yield* updateStatus(constants.CONTEXT_SETUP, {state: constants.STATUS_RUNNING, action: constants.ACTION_RUNNING, description: `The hamsters are working hard on your setup`});
         // returns output of container.inspect
         let containerStatus = yield container.create();
         // Save the container information for the build.
@@ -373,19 +366,19 @@ Server.prototype.runBuild = function* (build, log) {
         self.storeBuildData(build);
         log.info(`Container ready ${containerStatus.id}`, {id: containerStatus.Id, status: containerStatus.Status});
 
-        yield* updateStatus(SETUP_CONTEXT, {state: 'pending', action: 'running', description: 'Environment built'});
+        yield* updateStatus(constants.CONTEXT_SETUP, {state: constants.STATUS_SUCCESS, action: constants.ACTION_RUNNING, description: 'Environment built'});
       }
       catch (e) {
         switch (e.statusCode) {
           // container conflict, reuse existing container
           case 409:
-            log.warn(`Container ${containerName} is already exists, reusing it if not started`);
+            log.warn(`Container ${containerName} already exists, reusing it if not started`);
 
             var state = yield container.getState();
             if (state.Running) {
               // oh oh, there might be a problem
               log.error(`Container ${containerName} is already running, bailing`);
-              yield* updateStatus(SETUP_CONTEXT, {state: 'error', action: 'finished', description: 'Build already in progress'});
+              yield* updateStatus(constants.CONTEXT_SETUP, {state: constants.STATUS_FAIL, action: constants.ACTION_FINISHED, description: 'Build already in progress'});
               let err = new Error(`Build ${build.id} is already in progress`);
               err.status = 400;
               throw err;
@@ -393,12 +386,12 @@ Server.prototype.runBuild = function* (build, log) {
 
             yield container.start();
 
-            yield* updateStatus(SETUP_CONTEXT, {state: 'pending', action: 'running', description: 'Reusing existing environment'});
+            yield* updateStatus(constants.CONTEXT_SETUP, {state: constants.STATUS_SUCCESS, action: constants.ACTION_RUNNING, description: 'Reusing existing environment'});
             break;
 
           default:
             log.error({err: e}, 'Unknown container error');
-            yield* updateStatus(SETUP_CONTEXT, {state: 'error', action: 'finished', description: e.message});
+            yield* updateStatus(constants.CONTEXT_SETUP, {state: constants.STATUS_FAIL, action: constants.ACTION_FINISHED, description: e.message});
             throw e;
         }
       }
@@ -409,11 +402,11 @@ Server.prototype.runBuild = function* (build, log) {
       try {
         log.info('Running setup tasks');
         yield* runTasks(setupTasks, {log: log, container: container, loom: self.loom, setup: true});
-        yield* updateStatus(SETUP_CONTEXT, {state: 'success', action: 'finished', description: 'Environment ready'});
+        yield* updateStatus(constants.CONTEXT_SETUP, {state: constants.STATUS_SUCCESS, action: constants.ACTION_FINISHED, description: 'Environment ready'});
       }
       catch (e) {
         log.error({err: e}, 'Setup tasks failed: ' + e.message);
-        yield* updateStatus(SETUP_CONTEXT, {state: 'error', action: 'finished', description: 'Environment build failed: ' + e.message});
+        yield* updateStatus(constants.CONTEXT_SETUP, {state: constants.STATUS_FAIL, action: constants.ACTION_FINISHED, description: 'Environment build failed: ' + e.message});
 
         // bail on running the rest of the tasks
         setupSuccessful = false;
@@ -438,8 +431,8 @@ Server.prototype.runBuild = function* (build, log) {
 
         yield self.storeBuildDataAsync(build);
 
-        if (build.status === BUILD_STATUS_RUNNING) {
-          build.status = BUILD_STATUS_SUCCESSFUL;
+        if (build.status === constants.STATUS_RUNNING) {
+          build.status = constants.STATUS_SUCCESS;
         }
         self.storeBuildData(build);
         emitBuildEvent(build, 'ready', {}, {log, producer: self.buildEventsProducer});
@@ -460,7 +453,7 @@ Server.prototype.runBuild = function* (build, log) {
     build: {
       id: build.id,
     },
-    steps: userTasks.length,
+    steps: setupTasks.length + userTasks.length,
   };
 };
 
@@ -608,7 +601,7 @@ Server.prototype.deleteContainer = function(req, res, next) {
           build.reapedReason = reason;
 
           self.storeBuildData(build, function(err) {
-            emitBuildEvent(build, REAPED_EVENT, {}, {log: self.log, producer: self.buildEventsProducer});
+            emitBuildEvent(build, constants.EVENT_REAPED, {}, {log: self.log, producer: self.buildEventsProducer});
 
             res.json({status: 'removed', id: info.Id});
             return next();
@@ -660,7 +653,7 @@ Server.prototype.routes.post['container/proxy'] = function(req, res, next) {
 
     // lookup container object for the build
     // TODO: We should have an explicit status for if the build is in progress.
-    if (build.status === BUILD_STATUS_RUNNING) {
+    if (build.status === constants.STATUS_RUNNING) {
       if (!build.config || !build.config.allowAccessWhileBuilding) {
         res.setHeader('content-type', 'application/json');
         res.send(423, {buildId, errorCode: '423P', message: 'Build is still in progress'});

--- a/lib/GithubHandler.js
+++ b/lib/GithubHandler.js
@@ -252,9 +252,17 @@ GithubHandler.prototype.buildStatusUpdateHandler = function(update, build, done)
   var self = this;
   self.log.info({update: update, build_id: build.id}, 'Got build status update');
 
+  // Create a mapping of states that Github accepts
+  var stateMap = {
+    running: 'pending',
+    pending: 'pending',
+    success: 'success',
+    error: 'failure',
+  };
+
   var statusInfo = {
     // Can be one of pending, success, error, or failure.
-    state: update.state,
+    state: stateMap[update.state],
     description: update.description.substring(0, 140),
     context: update.context,
     target_url: update.target_url,

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {};
+
+// Statuses
+module.exports.STATUS_SUCCESS = 'success';
+module.exports.STATUS_FAIL = 'error';
+module.exports.STATUS_PENDING = 'pending';
+module.exports.STATUS_RUNNING = 'running';
+
+// Actions
+module.exports.ACTION_FINISHED = 'finished';
+module.exports.ACTION_RUNNING = 'running';
+module.exports.ACTION_PENDING = 'pending';
+
+// Context
+module.exports.CONTEXT_SETUP = 'env';
+
+// Events
+module.exports.EVENT_REAPED = 'reaped';

--- a/lib/plugins/TaskRunner/AbstractPlugin.js
+++ b/lib/plugins/TaskRunner/AbstractPlugin.js
@@ -8,6 +8,7 @@ var FlakeId = require('flake-idgen');
 var flakeIdGen = new FlakeId();
 var es = require('event-stream');
 var dockerRawStream = require('docker-raw-stream');
+var constants = require('../../constants');
 
 /**
  * @class
@@ -128,13 +129,13 @@ AbstractPlugin.prototype.run = function(done) {
   var self = this;
   var start = +new Date();
 
-  this.updateStatus({state: 'pending', action: 'running'});
+  this.updateStatus({state: constants.STATUS_RUNNING, action: constants.ACTION_RUNNING});
 
   function errorHandler(err, msg) {
     msg = msg || err.message;
 
     self.result.time = +new Date() - start;
-    self.updateStatus({state: 'error', action: 'finished', description: msg});
+    self.updateStatus({state: constants.STATUS_FAIL, action: constants.ACTION_FINISHED, description: msg});
 
     log.error({err: err}, msg);
     var wrappedError = new Error(msg);
@@ -184,8 +185,8 @@ AbstractPlugin.prototype.run = function(done) {
         self.result.time = +new Date() - start;
 
         self.updateStatus({
-          state: data.ExitCode === 0 ? 'success' : 'error',
-          action: 'finished',
+          state: data.ExitCode === 0 ? constants.STATUS_SUCCESS : constants.STATUS_FAIL,
+          action: constants.ACTION_FINISHED,
         });
 
         return data;


### PR DESCRIPTION
This update creates a new status / state called 'running,' to define the state when a task or build is actually in progress. As a result, in the future, only a task or build that has been scheduled but not started will be in the 'pending' state. Additionally, this update forces the use of status constants, so that there is no variation in the status naming convention (e.g. a failed build is always in the 'error' state, not 'failed' or 'failure').

**Side notes:**
1. The status constants were set based on values already contained in our database (e.g. the successful task status is called "success" to match our current values).
1. An environment / setup task (github downloader / asset downloader / etc) always had a status of 'pending' even after finishing. This is no longer the case, and the status will always reflect the actual task status ([updated by deleting a single line](https://github.com/ProboCI/probo/compare/create-running-state?expand=1#diff-ff131b5f771e36b49552d571bd125926L342))
1. A build's status is still named "state" so we don't need to do any kind of data migration to update this property. We may want to consider this in the future. ([build state defined here, for example](https://github.com/ProboCI/probo/compare/create-running-state?expand=1#diff-ff131b5f771e36b49552d571bd125926R312)).

**To test:**
Run some builds. Make sure the task statuses are correct on Github and in probo's web UI.

**Dependencies**
The PRs in BB Server and BB handlers. Not linking here since they are not open source.