### PR TITLE
Hide the asset url in the task output

### DIFF
--- a/lib/plugins/TaskRunner/AssetDownloader.js
+++ b/lib/plugins/TaskRunner/AssetDownloader.js
@@ -23,6 +23,7 @@ module.exports = class AssetDownloader extends require('./Script') {
     options.secrets = [
       options.bucket,
       options.token,
+      options.url,
     ];
 
     var script = [


### PR DESCRIPTION
This PR adds the asset receiver url as one of the protected secrets. That means logs will replace the url with asterisks instead of printing the url directly.