### PR TITLE
Update AssetDownloader test

### DIFF
--- a/test/tasks/AssetDownloader.js
+++ b/test/tasks/AssetDownloader.js
@@ -70,6 +70,7 @@ wget -nv -O files.tgz  http://asset.server/asset/bucket-name/files
     ad.options.secrets.should.eql([
       'bucket-name',
       'tok',
+      'http://asset.server',
     ]);
 
     ad.description().should.eql('AssetDownloader db.tgz, files');


### PR DESCRIPTION
The test should now ensure that the asset receiver URL is not revealed in the logs