### PR TITLE
Making build event constant usage consistent

### DIFF
--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -1,4 +1,3 @@
-/* eslint dot-notation: 1 */
 'use strict';
 
 var url = require('url');
@@ -439,7 +438,7 @@ Server.prototype.runBuild = function* (build, log) {
           build.status = constants.STATUS_SUCCESS;
         }
         self.storeBuildData(build);
-        emitBuildEvent(build, 'ready', {}, {log, producer: self.buildEventsProducer});
+        emitBuildEvent(build, constants.BUILD_EVENT_READY, {}, {log, producer: self.buildEventsProducer});
       }
       catch (error) {
         log.error({err: error}, 'Failed to write build to the BD');
@@ -609,7 +608,7 @@ Server.prototype.deleteContainer = function(req, res, next) {
           build.reapedDate = reapedDate;
 
           self.storeBuildData(build, function(err) {
-            emitBuildEvent(build, constants.EVENT_REAPED, {}, {log: self.log, producer: self.buildEventsProducer});
+            emitBuildEvent(build, constants.BUILD_EVENT_REAPED, {}, {log: self.log, producer: self.buildEventsProducer});
 
             res.json({status: 'removed', id: info.Id});
             return next();
@@ -938,7 +937,7 @@ Server.prototype.setPinnedStatus = function(req, res, status, next) {
         next(error);
         return;
       }
-      emitBuildEvent(build, 'updated', {}, {log: self.log, producer: self.buildEventsProducer});
+      emitBuildEvent(build, constants.BUILD_EVENT_UPDATED, {}, {log: self.log, producer: self.buildEventsProducer});
       res.send(build);
     });
   });

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -16,5 +16,7 @@ module.exports.ACTION_PENDING = 'pending';
 // Context
 module.exports.CONTEXT_SETUP = 'env';
 
-// Events
-module.exports.EVENT_REAPED = 'reaped';
+// Eventbus build_events event types.
+module.exports.BUILD_EVENT_REAPED = 'reaped';
+module.exports.BUILD_EVENT_READY = 'ready';
+module.exports.BUILD_EVENT_UPDATED = 'updated';


### PR DESCRIPTION
Build events were incompletely converted into constants imported from our constants file. This finishes the job.