### PR TITLE
#105 Allow table_prefix to be configurable in the Wordpress plugin

### DIFF
--- a/lib/plugins/TaskRunner/WordPressApp.js
+++ b/lib/plugins/TaskRunner/WordPressApp.js
@@ -37,7 +37,7 @@ class WordPressApp extends LAMPApp {
   constructor(container, options) {
     super(container, options);
     this.databaseName = options.databaseName || constants.WORDPRESS_DATABASE_NAME;
-
+    this.databaseTablePrefix = options.databaseTablePrefix || "wp_";
     this.options.siteFolder = options.siteFolder || 'default';
     this.options.profileName = options.profileName || 'standard';
     this.options.flushCaches = String(options.flushCaches) !== 'undefined' ? String(options.flushCaches).toLowerCase() === 'true' : true;
@@ -97,6 +97,7 @@ class WordPressApp extends LAMPApp {
       `define('DB_USER', '${constants.DATABASE_USER}');`,
       `define('DB_PASSWORD', '${constants.DATABASE_PASSWORD}');`,
       `define('DB_HOST', 'localhost');`,
+      `\$table_prefix = '${constants.DATABASE_TABLE_PREFIX}';`,
       `?>" >> /var/www/html/probo-config.php;`,
     ]);
   }


### PR DESCRIPTION
A blind attempt to make this work for table prefixes. I have no way to test it locally yet. Just curious to see what happens here.