### PR TITLE
Update package list before attempting to install.

### DIFF
--- a/lib/plugins/TaskRunner/LAMPApp.js
+++ b/lib/plugins/TaskRunner/LAMPApp.js
@@ -178,6 +178,7 @@ class LAMPApp extends Script {
     var packages = this.options.installPackages;
     if (!this.isEmptyObject(packages)) {
       var packageList = packages.join(' ');
+      this.script = this.script.concat('apt-get update');
       this.script = this.script.concat('apt-get install -y ' + packageList);
       this.options.restartApache = true;
     }


### PR DESCRIPTION
We allow users to specify additional packages they would like
installed in the probo.yaml file but we don't actually update the
package list. As a result the package can often not be found and
the task will fail. This change ensures that if additional
packages are requested, we update the apt list before attempting
to install.

## To test
- Create a lamp app and add a `installPackages` with something such as `php5-xdebug`
- Ensure that the package properly installs.