### PR TITLE
#108 databaseName option instead of constant in Drupal plugin

### DIFF
--- a/lib/plugins/TaskRunner/Drupal.js
+++ b/lib/plugins/TaskRunner/Drupal.js
@@ -15,6 +15,7 @@ class Drupal extends LAMPApp {
    *   @param {boolean} options.clearCaches - Whether to clear all caches after the build is finished. Defaults to true.
    *   @param {string} options.siteFolder - The site folder to use for this build (the folder within the drupal `sites` folder).  Defaults to `default`.
    *   @param {string} options.database - The name of the database to import if specified. Note that this database *must be added to the assets array separately*.
+   *   @param {string} options.databaseName - The name of the database. Defaults to 'drupal'.
    *   @param {boolean} options.databaseGzipped - Whether the database was sent gzipped and whether it should therefore be gunzipped before importing.
    *   @param {boolean} options.databaseBzipped - Whether the database was sent bzipped and whether it should therefore be bunzipped before importing.
    *   @param {boolean} options.databaseUpdates - Determines whether to run `drush updb`.
@@ -34,7 +35,7 @@ class Drupal extends LAMPApp {
   constructor(container, options) {
     super(container, options);
 
-    this.databaseName = constants.DRUPAL_DATABASE_NAME;
+    this.options.databaseName = options.databaseName || constants.DRUPAL_DATABASE_NAME;
 
     this.options.siteFolder = options.siteFolder || 'default';
     this.options.profileName = options.profileName || 'standard';
@@ -117,7 +118,7 @@ class Drupal extends LAMPApp {
       `\\$databases = array(`,
       `  'default' => array(`,
       `    'default' => array(`,
-      `      'database' => '${constants.DRUPAL_DATABASE_NAME}',`,
+      `      'database' => '${this.options.databaseName}',`,
       `      'username' => '${constants.DATABASE_USER}',`,
       `      'password' => '${constants.DATABASE_PASSWORD}',`,
       `      'host' => 'localhost',`,
@@ -144,7 +145,7 @@ class Drupal extends LAMPApp {
       `\\$databases = array(`,
       `  'default' => array(`,
       `    'default' => array(`,
-      `      'database' => '${constants.DRUPAL_DATABASE_NAME}',`,
+      `      'database' => '${this.options.databaseName}',`,
       `      'username' => '${constants.DATABASE_USER}',`,
       `      'password' => '${constants.DATABASE_PASSWORD}',`,
       `      'host' => 'localhost',`,

--- a/test/tasks/DrupalApp.js
+++ b/test/tasks/DrupalApp.js
@@ -25,6 +25,7 @@ describe('Drupal App', function() {
     };
     options2 = {
       database: 'my-cool-db.sql',
+      databaseName: 'drupal2',
       databaseGzipped: true,
       clearCaches: false,
     };
@@ -46,7 +47,7 @@ describe('Drupal App', function() {
   });
 
   it('should correctly instantiate', function(done) {
-    app.should.have.property('databaseName').which.eql(constants.DRUPAL_DATABASE_NAME);
+    app.should.have.property('databaseName').which.is.a.String;
     app.should.have.property('options').which.is.a.Object;
     app.options.should.have.property('siteFolder').which.eql('default');
     app.options.should.have.property('profileName').which.eql('standard');
@@ -188,8 +189,12 @@ describe('Drupal App', function() {
     app.script.should.containEql('if [ -a "$SRC_DIR/index.php" ]');
     app.script.should.containEql('ln -s $SRC_DIR  /var/www/html');
     app.script.should.containEql(`mysql -e 'create database ${constants.DRUPAL_DATABASE_NAME}'`);
+    app2.script.should.containEql(`mysql -e 'create database drupal2'`);
     app.script.should.containEql(
       `cat $ASSET_DIR/my-cool-db.sql | $(mysql -u ${constants.DATABASE_USER} --password=${constants.DATABASE_PASSWORD} ${constants.DRUPAL_DATABASE_NAME})`
+    );
+    app2.script.should.containEql(
+      `cat $ASSET_DIR/my-cool-db.sql | $(mysql -u ${constants.DATABASE_USER} --password=${constants.DATABASE_PASSWORD} drupal2)`
     );
     done();
   });
@@ -201,6 +206,7 @@ describe('Drupal App', function() {
 
   it('cats the settings.php file', function(done) {
     app.script.should.containEql(`'database' => '${constants.DRUPAL_DATABASE_NAME}'`);
+    app2.script.should.containEql(`'database' => 'drupal2'`);
     app.script.should.containEql(`'username' => '${constants.DATABASE_USER}'`);
     app.script.should.containEql(`'password' => '${constants.DATABASE_PASSWORD}'`);
     done();


### PR DESCRIPTION
This pull request allows a probo build using the Drupal plugin to specify the databaseName. This is useful when creating multisite installs on Probo.