### PR TITLE
Update the container-manage for compatibility with newer versions of docker

### DIFF
--- a/lib/Container.js
+++ b/lib/Container.js
@@ -186,6 +186,7 @@ Container.prototype.create = Promise.promisify(function(done) {
     name: self.containerName,
     Image: self.image,
     ExposedPorts: commandInfo.exposedPorts,
+    PortBindings: commandInfo.portBindings,
     Cmd: commandInfo.command,
     Env: [
       `COMMIT_REF=${this.build.commit.ref}`,
@@ -199,10 +200,7 @@ Container.prototype.create = Promise.promisify(function(done) {
   if (this.build.links && this.build.links.build) {
     createOptions.Env.push(`BUILD_DOMAIN=${this.build.links.build}`);
   }
-  var startOptions = {
-    PortBindings: commandInfo.portBindings,
-    Binds: self.binds,
-  };
+
   self.log.info('creating container');
   docker.createContainer(createOptions, function(error, container) {
     if (error) return done(error);
@@ -218,7 +216,7 @@ Container.prototype.create = Promise.promisify(function(done) {
         container.modem.demuxStream(stream, self.createLogWriteStream(), self.createLogWriteStream());
       });
     }
-    container.start(startOptions, function(error, data) {
+    container.start(function(error, data) {
       if (error) return done(error);
       container.inspect(function(error, data) {
         self.containerInfo = data;


### PR DESCRIPTION
To test:

1. Upgrade docker (I went right up to  `docker-engine=17.04.0~ce-0~ubuntu-trusty`).
2. Run a build (clicking rebuild is fine - watch the CM logs - you should see some error 400 from docker)
3. Checkout this branch and restart the CM
4. Run a build again - see it work.