### PR TITLE
Adding WordPress table prefix configuration.

### DIFF
--- a/lib/plugins/TaskRunner/WordPressApp.js
+++ b/lib/plugins/TaskRunner/WordPressApp.js
@@ -23,6 +23,8 @@ class WordPressApp extends LAMPApp {
    *      This is replaced by the probo url in the db.
    *   @param {boolean} [options.updatePlugins] - If true, will attempt to update
    *      wordpress plugins to latest versions. Defaults to false.
+   *   @param {string} [options.databasePrefix] - The prefix of the database.
+   *      Defaults to 'wp_'.
    *   @param {string} [options.databaseName] - The name of the database.
    *      Defaults to 'wordpress'.
    *   @param {boolean} [options.databaseGzipped] - Whether the database was
@@ -45,6 +47,7 @@ class WordPressApp extends LAMPApp {
     this.options.wpHome = options.wpHome || options.devHome || null;
     this.options.wpDomain = options.wpDomain || options.devDomain || null;
     this.options.updatePlugins = String(options.updatePlugins).toLowerCase() === 'true';
+    this.options.databasePrefix = options.databasePrefix || 'wp_';
     // TODO: Add some kind of validation.
 
     // Filter out secret strings
@@ -97,6 +100,7 @@ class WordPressApp extends LAMPApp {
       `define('DB_USER', '${constants.DATABASE_USER}');`,
       `define('DB_PASSWORD', '${constants.DATABASE_PASSWORD}');`,
       `define('DB_HOST', 'localhost');`,
+      `\$table_prefix = '${this.options.databasePrefix}'`,
       `?>" >> /var/www/html/probo-config.php;`,
     ]);
   }

--- a/test/tasks/Wordpress.js
+++ b/test/tasks/Wordpress.js
@@ -33,6 +33,7 @@ describe('WordPress plugin', function() {
       updatePlugins: true,
       databaseGzipped: true,
       flushCaches: false,
+      databasePrefix: 'coool_',
     };
 
     done();
@@ -86,10 +87,16 @@ describe('WordPress plugin', function() {
     done();
   });
 
+  it('should prefix the database as needed', function(done) {
+    app.script.should.containEql('$table_prefix = \'wp_\'');
+    app2.script.should.containEql('$table_prefix = \'coool_\'');
+    done();
+  });
+
   it('should correctly build up the script', function(done) {
     app.script = [];
     app.addScriptAppendWPConfigSettings();
-    app.script.should.have.length(10);
+    app.script.should.have.length(11);
     app.script.should.eql([
       'if [ ! -a "/var/www/html/wp-config.php" ] ; then',
       '  echo "<?php\ndefine(\'DB_NAME\', \'database_name_here\');\ndefine(\'DB_USER\', \'username_here\');\ndefine(\'DB_PASSWORD\', \'password_here\');\ndefine(\'DB_HOST\', \'localhost\');\ndefine(\'DB_CHARSET\', \'utf8\');\ndefine(\'DB_COLLATE\', \'\');\ndefine(\'AUTH_KEY\',         \'put your unique phrase here\');\ndefine(\'SECURE_AUTH_KEY\',  \'put your unique phrase here\');\ndefine(\'LOGGED_IN_KEY\',    \'put your unique phrase here\');\ndefine(\'NONCE_KEY\',        \'put your unique phrase here\');\ndefine(\'AUTH_SALT\',        \'put your unique phrase here\');\ndefine(\'SECURE_AUTH_SALT\', \'put your unique phrase here\');\ndefine(\'LOGGED_IN_SALT\',   \'put your unique phrase here\');\ndefine(\'NONCE_SALT\',       \'put your unique phrase here\');\n\\$table_prefix = \'wp_\';\ndefine(\'WP_DEBUG\', false);\nif ( !defined(\'ABSPATH\') )\n\tdefine(\'ABSPATH\', dirname(__FILE__) . \'/\');\nrequire_once(ABSPATH . \'wp-settings.php\');\n" > /var/www/html/wp-config.php',
@@ -100,6 +107,7 @@ describe('WordPress plugin', function() {
       'define(\'DB_USER\', \'root\');',
       'define(\'DB_PASSWORD\', \'strongpassword\');',
       'define(\'DB_HOST\', \'localhost\');',
+      '$table_prefix = \'wp_\'',
       '?>" >> /var/www/html/probo-config.php;',
     ]);
 
@@ -136,7 +144,7 @@ describe('WordPress plugin', function() {
 
     app.script = [];
     app.populateScriptArray();
-    app.script.should.have.length(35);
+    app.script.should.have.length(36);
 
     done();
   });


### PR DESCRIPTION
This is so that WordPress users can name their tables something other than the default 'wp_'. It is a security best practice to not use the default 'wp_' and we want to encourage that.

Please note: this may need to be rebased for the test for the number of lines in a Wordpress script, depending on merge order.