### PR TITLE
Change name of command run by container manager.

### DIFF
--- a/lib/Container.js
+++ b/lib/Container.js
@@ -363,7 +363,7 @@ Container.prototype.buildCommandInfo = function(image) {
     throw new Error('Use a real `image` in your .probo.yaml file');
   }
 
-  var command = ['penelope'];
+  var command = ['proboscis'];
   var exposedPorts = {};
   var portBindings = {};
   for (let name in image.services) {

--- a/lib/Container.js
+++ b/lib/Container.js
@@ -353,7 +353,7 @@ Container.prototype.getDiskUsage = Promise.promisify(function(done) {
 });
 
 /**
- * Build the command and port exposing logic for starting a penelope powered container.
+ * Build the command and port exposing logic for starting a proboscis powered container.
  *
  * @param {string} image - The name of the image we are extracting build command info for.
  * @return {object} - The command info on what is to be run.

--- a/test/fixtures/container_inspect.json
+++ b/test/fixtures/container_inspect.json
@@ -1,7 +1,7 @@
 {
     "Id": "fb9c62a0e8a8b32ba7698de4b20dd16bb1d5b27f7bfc91722ca73f53f612f861",
     "Created": "2015-12-11T06:45:01.302821753Z",
-    "Path": "penelope",
+    "Path": "proboscis",
     "Args": [
         "-n",
         "cleanapache",
@@ -151,7 +151,7 @@
             "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
         ],
         "Cmd": [
-            "penelope",
+            "proboscis",
             "-n",
             "cleanapache",
             "-c",


### PR DESCRIPTION
We have renamed the older dependency project from "lepew" to
"proboscis" and updated the code in proboscis. In order to run
builds using new containers that are built with this we should
run the newly named command as well.