### PR TITLE
Fixing bad phpIniOptions and phpConstants formatting.

### DIFF
--- a/lib/plugins/TaskRunner/LAMPApp.js
+++ b/lib/plugins/TaskRunner/LAMPApp.js
@@ -74,6 +74,11 @@ class LAMPApp extends Script {
   addScriptHeader() {
     this.script = this.script.concat([
       'READY=0; while ! `nc -z 127.0.0.1 3306` && [ $READY -lt 60 ]; do echo "Waiting for MySQL..."; READY=$((READY + 1)); sleep 1; done; if `nc -z 127.0.0.1 3306`; then echo "MySQL is ready."; else echo "MySQL failed to start!"; exit 1; fi;',
+
+      // Parse the php info to find where apache settings are stored. This is
+      // different on different operating systems, but this should work on all
+      // of them because it reads the loaded config.
+      `PHPINI_PATH="\$(php -i \| grep php.ini \| head -1 \| sed 's/\\\/cli//g' \| sed 's/.* //g')"`,
     ]);
   }
 
@@ -152,11 +157,10 @@ class LAMPApp extends Script {
         if (consts.hasOwnProperty(key)) {
           var val = this.sanitizeValue(consts[key]);
           phpText = phpText + `define ('${key}', ${val}); `;
-          this.script = this.script.concat(`cat /etc/php5/apache2/php.ini << EOL >> ${key}=${val}`);
         }
       }
-      this.script = this.script.concat(`echo "${phpText}" > $(SRC_DIR).proboPhpConstants.php`);
-      this.options.phpIniOptions.auto_prepend_file = '.proboPhpConstants.php';
+      this.script = this.script.concat(`echo "${phpText}" > $SRC_DIR/.proboPhpConstants.php`);
+      this.options.phpIniOptions.auto_prepend_file = '$SRC_DIR/.proboPhpConstants.php';
       this.options.restartApache = true;
     }
   }
@@ -167,7 +171,7 @@ class LAMPApp extends Script {
       for (var key in options) {
         if (options.hasOwnProperty(key)) {
           var val = this.sanitizeValue(options[key]);
-          this.script = this.script.concat(`cat /etc/php5/apache2/php.ini << EOL >> ${key}=${val}`);
+          this.script = this.script.concat(`echo "${key}=${val}" >> \$PHPINI_PATH/apache2/conf.d/99-probo-settings.ini`);
         }
       }
       this.options.restartApache = true;

--- a/test/tasks/LAMPApp.js
+++ b/test/tasks/LAMPApp.js
@@ -77,15 +77,19 @@ describe('LAMP App', function() {
     app.script.should.containEql('apt-get install -y php5-mcrypt my-cool-package');
   });
 
+  it('exports an variable for apache config directory', function() {
+    app.script.should.containEql(`PHPINI_PATH="$(php -i | grep php.ini | head -1 | sed \'s/\\/cli//g\' | sed \'s/.* //g\')"`);
+  });
+
   it('handles custom php options', function() {
-    app.script.should.containEql('cat /etc/php5/apache2/php.ini << EOL >> opcache.max_file_size=0');
-    app.script.should.containEql('cat /etc/php5/apache2/php.ini << EOL >> opcache.optimization_level=4294967295');
-    app.script.should.containEql('cat /etc/php5/apache2/php.ini << EOL >> soap.wsdl_cache_dir=\'/tmp\'');
+    app.script.should.containEql('echo "opcache.max_file_size=0" >> $PHPINI_PATH/apache2/conf.d/99-probo-settings.ini\n');
+    app.script.should.containEql('echo "opcache.optimization_level=4294967295" >> $PHPINI_PATH/apache2/conf.d/99-probo-settings.ini\n');
+    app.script.should.containEql('echo "soap.wsdl_cache_dir=\'/tmp\'" >> $PHPINI_PATH/apache2/conf.d/99-probo-settings.ini\n');
   });
 
   it('handles custom php defines', function() {
-    app.script.should.containEql('cat /etc/php5/apache2/php.ini << EOL >> auto_prepend_file=\'.proboPhpConstants.php\'');
-    app.script.should.containEql('echo "<?php define (\'PI\', 3.14); define (\'FUZZY_PI\', \'3.14ish\'); " > $(SRC_DIR).proboPhpConstants.php');
+    app.script.should.containEql('echo "auto_prepend_file=\'$SRC_DIR/.proboPhpConstants.php\'" >> $PHPINI_PATH/apache2/conf.d/99-probo-settings.ini\n');
+    app.script.should.containEql('echo "<?php define (\'PI\', 3.14); define (\'FUZZY_PI\', \'3.14ish\'); " > $SRC_DIR/.proboPhpConstants.php');
   });
 
   it('handles custom php mods', function() {

--- a/test/tasks/Wordpress.js
+++ b/test/tasks/Wordpress.js
@@ -136,7 +136,7 @@ describe('WordPress plugin', function() {
 
     app.script = [];
     app.populateScriptArray();
-    app.script.should.have.length(35);
+    app.script.should.have.length(36);
 
     done();
   });


### PR DESCRIPTION
The previous formatting was unterminated and caused probo builds to hang
indefinitely.


Please note: this may need to be rebased for the test for the number of lines in a Wordpress script, depending on merge order.