### PR TITLE
Adding nightly docker image tags to probo images whitelist.

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -152,6 +152,141 @@ images:
         command: '/opt/solr/start.sh'
       php_log:
         command: 'tail -F /var/log/php/error.log'
+  'proboci/ubuntu-14.04-lamp:php5.6-nightly':
+    services:
+      cleanapache:
+        command: 'rm /var/run/apache2/apache2.pid'
+      apache:
+        command: '/usr/sbin/apache2ctl -D FOREGROUND'
+        port: 80
+      mysql:
+        command: 'mysqld_safe'
+      redis:
+        command: 'redis-server'
+      solr:
+        command: '/opt/solr/start.sh'
+      php_log:
+        command: 'tail -F /var/log/php/error.log'
+  'proboci/ubuntu-14.04-lamp:php7.0-nightly':
+    services:
+      cleanapache:
+        command: 'rm /var/run/apache2/apache2.pid'
+      apache:
+        command: '/usr/sbin/apache2ctl -D FOREGROUND'
+        port: 80
+      mysql:
+        command: 'mysqld_safe'
+      redis:
+        command: 'redis-server'
+      solr:
+        command: '/opt/solr/start.sh'
+      php_log:
+        command: 'tail -F /var/log/php/error.log'
+  'proboci/ubuntu-14.04-lamp:php7.1-nightly':
+    services:
+      cleanapache:
+        command: 'rm /var/run/apache2/apache2.pid'
+      apache:
+        command: '/usr/sbin/apache2ctl -D FOREGROUND'
+        port: 80
+      mysql:
+        command: 'mysqld_safe'
+      redis:
+        command: 'redis-server'
+      solr:
+        command: '/opt/solr/start.sh'
+      php_log:
+        command: 'tail -F /var/log/php/error.log'
+  'proboci/ubuntu-14.04-lamp:php7.2-nightly':
+    services:
+      cleanapache:
+        command: 'rm /var/run/apache2/apache2.pid'
+      apache:
+        command: '/usr/sbin/apache2ctl -D FOREGROUND'
+        port: 80
+      mysql:
+        command: 'mysqld_safe'
+      redis:
+        command: 'redis-server'
+      solr:
+        command: '/opt/solr/start.sh'
+      php_log:
+        command: 'tail -F /var/log/php/error.log'
+  'proboci/ubuntu-14.04-lamp:latest':
+    services:
+      cleanapache:
+        command: 'rm /var/run/apache2/apache2.pid'
+      apache:
+        command: '/usr/sbin/apache2ctl -D FOREGROUND'
+        port: 80
+      mysql:
+        command: 'mysqld_safe'
+      redis:
+        command: 'redis-server'
+      solr:
+        command: '/opt/solr/start.sh'
+      php_log:
+        command: 'tail -F /var/log/php/error.log'
+  'proboci/ubuntu-16.04-lamp:php7.0-nightly':
+    services:
+      cleanapache:
+        command: 'rm /var/run/apache2/apache2.pid'
+      apache:
+        command: '/usr/sbin/apache2ctl -D FOREGROUND'
+        port: 80
+      mysql:
+        command: 'mysqld_safe'
+      redis:
+        command: 'redis-server'
+      solr:
+        command: '/opt/solr/start.sh'
+      php_log:
+        command: 'tail -F /var/log/php/error.log'
+  'proboci/ubuntu-16.04-lamp:php7.1-nightly':
+    services:
+      cleanapache:
+        command: 'rm /var/run/apache2/apache2.pid'
+      apache:
+        command: '/usr/sbin/apache2ctl -D FOREGROUND'
+        port: 80
+      mysql:
+        command: 'mysqld_safe'
+      redis:
+        command: 'redis-server'
+      solr:
+        command: '/opt/solr/start.sh'
+      php_log:
+        command: 'tail -F /var/log/php/error.log'
+  'proboci/ubuntu-16.04-lamp:php7.2-nightly':
+    services:
+      cleanapache:
+        command: 'rm /var/run/apache2/apache2.pid'
+      apache:
+        command: '/usr/sbin/apache2ctl -D FOREGROUND'
+        port: 80
+      mysql:
+        command: 'mysqld_safe'
+      redis:
+        command: 'redis-server'
+      solr:
+        command: '/opt/solr/start.sh'
+      php_log:
+        command: 'tail -F /var/log/php/error.log'
+  'proboci/ubuntu-16.04-lamp:latest':
+    services:
+      cleanapache:
+        command: 'rm /var/run/apache2/apache2.pid'
+      apache:
+        command: '/usr/sbin/apache2ctl -D FOREGROUND'
+        port: 80
+      mysql:
+        command: 'mysqld_safe'
+      redis:
+        command: 'redis-server'
+      solr:
+        command: '/opt/solr/start.sh'
+      php_log:
+        command: 'tail -F /var/log/php/error.log'
 dataDir: './container-manager-data'
 # Volumes to mount into created containers.
 binds: []


### PR DESCRIPTION
I've tested all of the current -nightly builds on our docker hub account locally and they are working against the PRs I have created. The PRs below are the generic tests I did to ensure a build would run on each 14.04 and 16.04 image we are building with the [Probo Image Builder](https://github.com/ProboCI/probo-image-builder).

https://github.com/Probo-Demos/local-testing/pull/4
https://github.com/Probo-Demos/local-testing/pull/5
https://github.com/Probo-Demos/local-testing/pull/6
https://github.com/Probo-Demos/local-testing/pull/7
https://github.com/Probo-Demos/local-testing/pull/8
https://github.com/Probo-Demos/local-testing/pull/9
https://github.com/Probo-Demos/local-testing/pull/10

Allowing these nightly images should get us in a good position to start pushing nightly docker hub images that have all the latest and greatest versions of packages included in our images.

I made sure the :latest tag was on the list for 14.04 and 16.04 so we can use a general latest image also.