### PR TITLE
Fix/sk33lz/docker image commands

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -164,7 +164,7 @@ images:
       redis:
         command: 'redis-server'
       solr:
-        command: '/opt/solr/start.sh'
+        command: 'service solr start'
       php_log:
         command: 'tail -F /var/log/php/error.log'
   'proboci/ubuntu-14.04-lamp:php7.0-nightly':
@@ -179,7 +179,7 @@ images:
       redis:
         command: 'redis-server'
       solr:
-        command: '/opt/solr/start.sh'
+        command: 'service solr start'
       php_log:
         command: 'tail -F /var/log/php/error.log'
   'proboci/ubuntu-14.04-lamp:php7.1-nightly':
@@ -194,7 +194,7 @@ images:
       redis:
         command: 'redis-server'
       solr:
-        command: '/opt/solr/start.sh'
+        command: 'service solr start'
       php_log:
         command: 'tail -F /var/log/php/error.log'
   'proboci/ubuntu-14.04-lamp:php7.2-nightly':
@@ -209,7 +209,7 @@ images:
       redis:
         command: 'redis-server'
       solr:
-        command: '/opt/solr/start.sh'
+        command: 'service solr start'
       php_log:
         command: 'tail -F /var/log/php/error.log'
   'proboci/ubuntu-14.04-lamp:latest':
@@ -224,7 +224,7 @@ images:
       redis:
         command: 'redis-server'
       solr:
-        command: '/opt/solr/start.sh'
+        command: 'service solr start'
       php_log:
         command: 'tail -F /var/log/php/error.log'
   'proboci/ubuntu-16.04-lamp:php7.0-nightly':
@@ -239,7 +239,7 @@ images:
       redis:
         command: 'redis-server'
       solr:
-        command: '/opt/solr/start.sh'
+        command: 'service solr start'
       php_log:
         command: 'tail -F /var/log/php/error.log'
   'proboci/ubuntu-16.04-lamp:php7.1-nightly':
@@ -254,7 +254,7 @@ images:
       redis:
         command: 'redis-server'
       solr:
-        command: '/opt/solr/start.sh'
+        command: 'service solr start'
       php_log:
         command: 'tail -F /var/log/php/error.log'
   'proboci/ubuntu-16.04-lamp:php7.2-nightly':
@@ -269,7 +269,7 @@ images:
       redis:
         command: 'redis-server'
       solr:
-        command: '/opt/solr/start.sh'
+        command: 'service solr start'
       php_log:
         command: 'tail -F /var/log/php/error.log'
   'proboci/ubuntu-16.04-lamp:latest':
@@ -284,7 +284,7 @@ images:
       redis:
         command: 'redis-server'
       solr:
-        command: '/opt/solr/start.sh'
+        command: 'service solr start'
       php_log:
         command: 'tail -F /var/log/php/error.log'
 dataDir: './container-manager-data'

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -197,21 +197,6 @@ images:
         command: 'service solr start'
       php_log:
         command: 'tail -F /var/log/php/error.log'
-  'proboci/ubuntu-14.04-lamp:php7.2-nightly':
-    services:
-      cleanapache:
-        command: 'rm /var/run/apache2/apache2.pid'
-      apache:
-        command: '/usr/sbin/apache2ctl -D FOREGROUND'
-        port: 80
-      mysql:
-        command: 'mysqld_safe'
-      redis:
-        command: 'redis-server'
-      solr:
-        command: 'service solr start'
-      php_log:
-        command: 'tail -F /var/log/php/error.log'
   'proboci/ubuntu-14.04-lamp:latest':
     services:
       cleanapache:
@@ -258,21 +243,6 @@ images:
       php_log:
         command: 'tail -F /var/log/php/error.log'
   'proboci/ubuntu-16.04-lamp:php7.2-nightly':
-    services:
-      cleanapache:
-        command: 'rm /var/run/apache2/apache2.pid'
-      apache:
-        command: '/usr/sbin/apache2ctl -D FOREGROUND'
-        port: 80
-      mysql:
-        command: 'mysqld_safe'
-      redis:
-        command: 'redis-server'
-      solr:
-        command: 'service solr start'
-      php_log:
-        command: 'tail -F /var/log/php/error.log'
-  'proboci/ubuntu-16.04-lamp:latest':
     services:
       cleanapache:
         command: 'rm /var/run/apache2/apache2.pid'


### PR DESCRIPTION
The solr script that existed in the older docker images we used to build with Puppet no longer exists, as we are now using the apt repo we setup for solr instead and it starts as a service.

I've gone ahead and changed that line to just `service solr start` to ensure it starts on container start.

This has been tested locally against the 14.04 nightly images without any issues that I can see.

I did however run into some issues with the Drupal plugin on 16.04 as the netcat service that checks if mysql is running does not exist on the 16.04 images. We need to debug that, but PR should be good to go for the new 14.04 images.