### PR TITLE
Add stage_file_proxy to Drupal setup for magic file serving.

### DIFF
--- a/lib/plugins/TaskRunner/Drupal.js
+++ b/lib/plugins/TaskRunner/Drupal.js
@@ -29,6 +29,7 @@ class Drupal extends LAMPApp {
    *   @param {string} options.configSyncDirectory - The config sync directory used in Drupal 8.
    *   @param {string} [options.settingsAppend] - A snippet to append to the end of the settings.php file.
    *   @param {string} [options.settingsRequireFile] - A file to require at the end of settings.php (in order to get around not
+   *   @param {string} [options.fileProxy] - If a file doesn't exist in the repository, the file can be retrieved from the production instance of the site. Enter the protocol and fully qualified domain here, as in "https://example.com".
    *      checking settings.php into your repo).
    *   @augments LAMPApp
    */
@@ -94,6 +95,9 @@ class Drupal extends LAMPApp {
     }
     if (this.options.revertFeatures) {
       this.addScriptRevertFeatures();
+    }
+    if (this.options.fileProxy) {
+      this.addScriptFileProxy();
     }
     if (this.options.clearCaches) {
       this.addScriptClearCaches();
@@ -213,6 +217,14 @@ class Drupal extends LAMPApp {
     else {
       this.script.push('drush --root=/var/www/html cache-clear all');
     }
+  }
+
+  addScriptFileProxy() {
+    this.script = this.script.concat(
+      `drush --root=/var/www/html en stage_file_proxy -y`,
+      `drush --root=/var/www/html vset stage_file_proxy_hotlink 1`,
+      `drush --root=/var/www/html vset stage_file_proxy_origin '${this.options.fileProxy}'`
+    );
   }
 
   drupalVersionSupported() {

--- a/test/tasks/DrupalApp.js
+++ b/test/tasks/DrupalApp.js
@@ -22,6 +22,7 @@ describe('Drupal App', function() {
   before(function(done) {
     options = {
       database: 'my-cool-db.sql',
+      fileProxy: 'https://example.com',
     };
     options2 = {
       database: 'my-cool-db.sql',
@@ -215,6 +216,14 @@ describe('Drupal App', function() {
   it('clears the cache', function(done) {
     app.script.should.containEql('drush --root=/var/www/html cache-clear all');
     app2.script.should.not.containEql('drush --root=/var/www/html cache-clear all');
+    done();
+  });
+
+  it('should enable stage_file_proxy', function(done) {
+    app2.script.should.not.containEql('stage_file_proxy');
+    app.script.should.containEql('en stage_file_proxy');
+    app.script.should.containEql('vset stage_file_proxy_hotlink 1');
+    app.script.should.containEql('vset stage_file_proxy_origin \'https://example.com\'');
     done();
   });
 


### PR DESCRIPTION
Functional testing:

Add `fileProxy: 'https://example.com'` to Drupal plugin config (feel free to fork https://github.com/dzink/lisas-saxamaphone/pull/3 , I can give you the db if needed)

Create PR and enter docker instance.

Run:

`drush vget stage_*`

you should see:
stage_file_proxy_hotlink: 1
stage_file_proxy_origin: 'https://example.com'

Run:

`drush pml | grep stage_`

you should see something like:
 Other     Stage File Proxy (stage_file_proxy)    Module  Enabled        7.x-1.7

Then of course run unit tests.