### PR TITLE
Adding phpIniOptions for PHP cli.

### DIFF
--- a/lib/plugins/TaskRunner/LAMPApp.js
+++ b/lib/plugins/TaskRunner/LAMPApp.js
@@ -172,6 +172,7 @@ class LAMPApp extends Script {
         if (options.hasOwnProperty(key)) {
           var val = this.sanitizeValue(options[key]);
           this.script = this.script.concat(`echo "${key}=${val}" >> \$PHPINI_PATH/apache2/conf.d/99-probo-settings.ini`);
+          this.script = this.script.concat(`echo "${key}=${val}" >> \$PHPINI_PATH/cli/conf.d/99-probo-settings.ini`);
         }
       }
       this.options.restartApache = true;


### PR DESCRIPTION
This PR adds a 99-probo-settings config file in the phpIniOptions function for PHP.ini changes for PHP CLI.