### PR TITLE
Adding a useful error message for Probo images.

### DIFF
--- a/lib/Container.js
+++ b/lib/Container.js
@@ -360,7 +360,7 @@ Container.prototype.getDiskUsage = Promise.promisify(function(done) {
  */
 Container.prototype.buildCommandInfo = function(image) {
   if (!image) {
-    throw new Error('Use a real `image` in your .probo.yaml file');
+    throw new Error('Use an approved Probo Image in your .probo.yaml file. See https://docs.probo.ci/build/images/ for approved Probo Images.');
   }
 
   var command = ['proboscis'];


### PR DESCRIPTION
Added link to https://docs.probo.ci/build/images/ to the error so users can find an approved image to use.