### PR TITLE
Allow cli and apache in php ini settings

### DIFF
--- a/lib/plugins/TaskRunner/LAMPApp.js
+++ b/lib/plugins/TaskRunner/LAMPApp.js
@@ -167,14 +167,28 @@ class LAMPApp extends Script {
 
   addScriptPhpIniOptions() {
     var options = this.options.phpIniOptions;
+    let paths = ['apache2', 'cli'];
     if (!this.isEmptyObject(options)) {
-      for (var key in options) {
-        if (options.hasOwnProperty(key)) {
-          var val = this.sanitizeValue(options[key]);
-          this.script = this.script.concat(`echo "${key}=${val}" >> \$PHPINI_PATH/apache2/conf.d/99-probo-settings.ini`);
+      for (let key in paths) {
+        let path = paths[key];
+        if (options[path] != undefined) {
+          this.addPhpOptionsToPath([path], options[path]);
+          delete options[path];
         }
       }
+      this.addPhpOptionsToPath(paths, options);
       this.options.restartApache = true;
+    }
+  }
+
+  addPhpOptionsToPath(paths, options) {
+    for (let pathKey in paths) {
+      for (let key in options) {
+        if (options.hasOwnProperty(key)) {
+          let val = this.sanitizeValue(options[key]);
+          this.script = this.script.concat(`echo "${key}=${val}" >> \$PHPINI_PATH/${paths[pathKey]}/conf.d/99-probo-settings.ini`);
+        }
+      }
     }
   }
 

--- a/lib/plugins/TaskRunner/LAMPApp.js
+++ b/lib/plugins/TaskRunner/LAMPApp.js
@@ -18,7 +18,7 @@ class LAMPApp extends Script {
    *   @param {boolean} [options.databaseBzipped] - Whether the database was sent bzipped and whether it should therefore be bunzipped before importing.
    *   @param {string} [options.subDirectory] - The directory of the actual web root (defaults to 'docroot').
    *   @param {hash} [options.cliDefines] - A hash of defines, such as {define1: 'define1Value', define2: 'define2Value',}
-   *   @param {hash} [options.phpIniOptions] - A hash of options, such as {option1: 'option1Value', option2: 'option2Value',}
+   *   @param {hash} [options.phpIniOptions] - A hash of options for all, apache2, and cli e.g. {all: {option1: 'option1Value', option2: 'option2Value'}}
    *   @param {hash} [options.phpConstants] - A hash of constants, such as {const1: 'const1Value', const2: 'const2Value',}.
    *      This will overwrite any other auto_prepend_file directives in your php.ini.
    *   @param {array} [options.installPackages] - An array of additional packages to install.
@@ -35,6 +35,7 @@ class LAMPApp extends Script {
     this.databaseName = options.databaseName || 'lampdb';
     this.options.cliDefines = options.cliDefines || {};
     this.options.phpIniOptions = options.phpIniOptions || {};
+    this.options.phpIniOptions.all = options.phpIniOptions.all || {};
     this.options.phpConstants = options.phpConstants || {};
     this.options.installPackages = options.installPackages || {};
     this.options.phpMods = options.phpMods || {};
@@ -160,23 +161,27 @@ class LAMPApp extends Script {
         }
       }
       this.script = this.script.concat(`echo "${phpText}" > $SRC_DIR/.proboPhpConstants.php`);
-      this.options.phpIniOptions.auto_prepend_file = '$SRC_DIR/.proboPhpConstants.php';
+      this.options.phpIniOptions.all.auto_prepend_file = '$SRC_DIR/.proboPhpConstants.php';
       this.options.restartApache = true;
     }
   }
 
   addScriptPhpIniOptions() {
     var options = this.options.phpIniOptions;
-    let paths = ['apache2', 'cli'];
+    let paths = {
+      all: ['apache2', 'cli'],
+      apache2: ['apache2'],
+      cli: ['cli'],
+    };
     if (!this.isEmptyObject(options)) {
       for (let key in paths) {
         let path = paths[key];
-        if (options[path] != undefined) {
-          this.addPhpOptionsToPath([path], options[path]);
-          delete options[path];
+        if (options[key] != undefined) {
+          this.addPhpOptionsToPath(path, options[key]);
+          delete options[key];
         }
       }
-      this.addPhpOptionsToPath(paths, options);
+      this.addPhpOptionsToPath(paths.all, options);
       this.options.restartApache = true;
     }
   }

--- a/lib/plugins/TaskRunner/LAMPApp.js
+++ b/lib/plugins/TaskRunner/LAMPApp.js
@@ -199,13 +199,16 @@ class LAMPApp extends Script {
   }
 
   addScriptPhpIniOptions() {
-    var options = this.options.phpIniOptions;
-    let paths = {
-      all: ['apache2', 'cli'],
-      apache2: ['apache2'],
-      cli: ['cli'],
-    };
-    if (!this.isEmptyObject(options)) {
+    if (!this.isEmptyObject(this.options.phpIniOptions)) {
+      // We clone the object because we modify it
+      // and will mess things up if this is run
+      // multiple times.
+      let options = JSON.parse(JSON.stringify(this.options.phpIniOptions));
+      let paths = {
+        all: ['apache2', 'cli'],
+        apache2: ['apache2'],
+        cli: ['cli'],
+      };
       for (let key in paths) {
         let path = paths[key];
         if (options[key] != undefined) {

--- a/test/tasks/LAMPApp.js
+++ b/test/tasks/LAMPApp.js
@@ -25,6 +25,9 @@ describe('LAMP App', function() {
       'opcache.max_file_size': 0,
       'opcache.optimization_level': 0xffffffff,
       'soap.wsdl_cache_dir': '/tmp',
+      'cli': {
+        'memory_limit': '256M',
+      },
     },
     apacheMods: ['dir', 'my-cool-apachemod'],
     phpMods: ['mcrypt', 'my-cool-php5mod'],
@@ -85,6 +88,9 @@ describe('LAMP App', function() {
     app.script.should.containEql('echo "opcache.max_file_size=0" >> $PHPINI_PATH/apache2/conf.d/99-probo-settings.ini\n');
     app.script.should.containEql('echo "opcache.optimization_level=4294967295" >> $PHPINI_PATH/apache2/conf.d/99-probo-settings.ini\n');
     app.script.should.containEql('echo "soap.wsdl_cache_dir=\'/tmp\'" >> $PHPINI_PATH/apache2/conf.d/99-probo-settings.ini\n');
+    app.script.should.containEql('echo "soap.wsdl_cache_dir=\'/tmp\'" >> $PHPINI_PATH/cli/conf.d/99-probo-settings.ini\n');
+    app.script.should.containEql('echo "memory_limit=\'256M\'" >> $PHPINI_PATH/cli/conf.d/99-probo-settings.ini\n');
+    app.script.should.not.containEql('echo "memory_limit=\'256M\'" >> $PHPINI_PATH/apache2/conf.d/99-probo-settings.ini\n');
   });
 
   it('handles custom php defines', function() {

--- a/test/tasks/LAMPApp.js
+++ b/test/tasks/LAMPApp.js
@@ -28,6 +28,9 @@ describe('LAMP App', function() {
       'cli': {
         'memory_limit': '256M',
       },
+      'all': {
+        'post_max_size': '20M',
+      }
     },
     apacheMods: ['dir', 'my-cool-apachemod'],
     phpMods: ['mcrypt', 'my-cool-php5mod'],
@@ -90,6 +93,8 @@ describe('LAMP App', function() {
     app.script.should.containEql('echo "soap.wsdl_cache_dir=\'/tmp\'" >> $PHPINI_PATH/apache2/conf.d/99-probo-settings.ini\n');
     app.script.should.containEql('echo "soap.wsdl_cache_dir=\'/tmp\'" >> $PHPINI_PATH/cli/conf.d/99-probo-settings.ini\n');
     app.script.should.containEql('echo "memory_limit=\'256M\'" >> $PHPINI_PATH/cli/conf.d/99-probo-settings.ini\n');
+    app.script.should.containEql('echo "post_max_size=\'20M\'" >> $PHPINI_PATH/cli/conf.d/99-probo-settings.ini\n');
+    app.script.should.containEql('echo "post_max_size=\'20M\'" >> $PHPINI_PATH/apache2/conf.d/99-probo-settings.ini\n');
     app.script.should.not.containEql('echo "memory_limit=\'256M\'" >> $PHPINI_PATH/apache2/conf.d/99-probo-settings.ini\n');
   });
 


### PR DESCRIPTION
If users supply the phpinioptions as they currently are, then the settings go to both apache and cli.  However, they can supply optionally supply options for cli and apache2 within the options and those will only apply to the specified path:

```
phpIniOptions:
      upload_max_filesize: 26M
      post_max_size: 25M
      memory_limit: 256M
      apache2:
           error_reporting: E_ALL ~E_DEPRECATED
           display_errors: 0
      cli:
           error_reporting: E_ALL
```