### PR TITLE
Remove containers only through build deletion request

### DIFF
--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -1,27 +1,31 @@
 'use strict';
 
-var url = require('url');
-var Docker = require('dockerode');
-var Promise = require('bluebird');
-var co = require('../lib/safeco');
-var FlakeId = require('flake-idgen');
-var restify = require('restify');
-var level = require('level');
-var JSONStream = require('JSONStream');
-var through2 = require('through2');
-var async = require('async');
-var ms = require('ms');
-var _ = require('lodash');
-var wait = require('co-wait');
-var waitForPort = require('./waitForPort');
-var Container = require('./Container');
-var logger = require('./logger');
-var runTasks = require('./container_manager/task_runner');
-var loom = require('./loom');
-var eventbus = require('probo-eventbus');
-var constants = require('./constants');
-const uuidv4 = require('uuid/v4');
+const _ = require('lodash');
+const async = require('async');
+const Docker = require('dockerode');
+const eventbus = require('probo-eventbus');
+const FlakeId = require('flake-idgen');
+const JSONStream = require('JSONStream');
+const level = require('level');
+const ms = require('ms');
+const Promise = require('bluebird');
 const requestLogger = require('probo-request-logger');
+const restify = require('restify');
+const restifyErrors = require('restify-errors');
+const through2 = require('through2');
+const url = require('url');
+const uuidv4 = require('uuid/v4');
+const wait = require('co-wait');
+
+const constants = require('./constants');
+const Container = require('./Container');
+const loom = require('./loom');
+const logger = require('./logger');
+const runTasks = require('./container_manager/task_runner');
+const waitForPort = require('./waitForPort');
+
+
+var co = require('./safeco');
 
 Promise.longStackTraces();
 
@@ -523,102 +527,69 @@ Server.prototype.routes.get.containers = function(req, res, next) {
 };
 
 /**
- * Delete the docker container from the server. THIS OPERATION CANNOT BE REVERSED!
- * By default, will not remove running containers.
- * Call with ?force=true delete running containers too.
- * @param {object} req - Restify request object.
- * @param {object} res - Restify response object.
- * @param {Function} next - The next middleware to call.
+ * Removes the container and updates the build entry in the database.
+ *
+ * @param {string} containerId - The ID of the container to remove.
+ * @param {Object.<any, any>} build - The build object.
+ * @param {Object.<string, stirng|bool>} reapInfo - The information on the build
+ *   to reap.
+ * @param {(err: Error, build: any) => void} cb - The callback function.
  */
-Server.prototype.routes.del['containers/:id/'] = function(req, res, next) {
-  this.deleteContainer(req, res, next);
-};
+Server.prototype.deleteContainer = function(containerId, build, reapInfo, cb) {
 
-
-Server.prototype.deleteContainer = function(req, res, next) {
-  let self = this;
-  let reason = req.query.reason || 0;
-  let reasonText = (req.query.reasonText) ? decodeURIComponent(req.query.reasonText) : 'This build was deleted for an unknown reason.';
-  let reapedDate = req.query.reapedDate || Date.now();
-
-  // delete/remove the container and update the build entry in the DB
   let container = new Container({
     docker: this.config.docker,
-    containerId: req.params.id,
+    containerId: containerId,
     log: this.log,
   });
+
   logContainerEvents(container);
 
-  function handleError(err, msg) {
-    msg = msg ? msg + ': ' : '';
-    let message = msg + (err.json || err.message);
-    let code = err.statusCode || 500;
-    res.send(code, {error: message.trim(), code: code});
-    next();
-  }
-
-  container.inspect(function(err, info) {
+  container.inspect(err => {
     if (err) {
-      return handleError(err);
+      // If container was already removed, continue so we can update build.
+      if (err.statusCode !== 404) {
+        return cb(err);
+      }
     }
 
-    // name is: probo--[repo slug]--[project id]--[buildid]
-    let buildId = info.Name.split('--')[3];
+    // Sets the build on the container so that it's available to container event
+    // listeners.
+    container.build = build;
 
-    if (!buildId) {
-      err = new Error(`BuildId not found for container name ${info.Name}`);
-      err.statusCode = 400;
-      return handleError(err);
-    }
-
-    // Reason must be a non-negative integer.
-    if (!Number.isInteger(parseFloat(reason)) || reason < 0) {
-      err = new Error('Invalid reason');
-      err.statusCode = 500;
-      return handleError(err);
-    }
-
-    // find matching build object
-    self.getBuildData(buildId, function(err, build) {
+    container.remove({force: reapInfo.force}, err => {
       if (err) {
-        self.log.error({err}, `Could not find build for buildId ${buildId}`);
-        return handleError(err, `Could not find build for buildId ${buildId}`);
+        // If container was already removed, continue so we can update build.
+        if (err.statusCode !== 404) {
+          return cb(err);
+        }
       }
 
-      // set the build on the container so that it's available to container event listeners
-      container.build = build;
-
-      container.remove({force: req.query.force, v: req.query.v}, function(err, data) {
+      this.updateBuildContainerStatus(build, (err, build) => {
         if (err) {
-          return handleError(err);
+          this.log.error({err, container: build.container},
+            `Could not update container status for build ${buildId}`);
+
+          return cb(err);
         }
-        self.log.info({build}, 'Got build object to update');
 
-        self.updateBuildContainerStatus(build, function(err, build) {
-          if (err) {
-            self.log.error({err, container: build.container}, `Could not update container status for build ${buildId}, continuing`);
-          }
+        this.log.info({container: build.container}, 'Update build container info');
 
-          self.log.info({container: build.container}, 'Update build container info');
+        // Sets the reaped flag to true to help upstream event processors have
+        // more context.
+        build.reaped = true;
+        build.reapedReason = reapInfo.reason;
+        build.reapedReasonText = reapInfo.reasonText;
+        build.reapedDate = reapInfo.reapedDate;
 
-          // set the reaped flag to true to help upstream event processors have more context
-          build.reaped = true;
-          build.reapedReason = reason;
-          build.reapedReasonText = reasonText;
-          build.reapedDate = reapedDate;
-
-          self.storeBuildData(build, function(err) {
-            emitBuildEvent(build, constants.BUILD_EVENT_REAPED, {}, {log: self.log, producer: self.buildEventsProducer});
-
-            res.json({status: 'removed', id: info.Id});
-            return next();
-          });
-        });
+        return cb(null, build);
       });
-    });
-  });
-};
 
+    });
+
+  });
+
+};
 
 /**
  * Get information about an active container for a build.
@@ -780,15 +751,17 @@ Server.prototype.routes.post['container/proxy'] = function(req, res, next) {
 };
 
 /**
- * List builds on this server that have a matching existing container (by default).
- * Use ?all=true query param to get all build records.
+ * List builds on this server that have a matching existing container (by
+ * default). Use ?all=true query param to get all build records.
  * NOTE: does NOT do a live check for an existing container. Relies on meta-data that's in the build.container object.
- * @param {object} req - Restify request object.
- * @param {object} res - Restify response object.
- * @param {Function} next - The next middleware to call.
+ *
+ * @param {import('restify').Request} req - Restify request object.
+ * @param {import('restify').Response} res - Restify response object.
+ * @param {import('restify').Next} next - The next middleware to call.
  */
 Server.prototype.routes.get.builds = function(req, res, next) {
   var readStream = this.streamFromDB('builds');
+
   var jsonStream = new JSONStream.stringify();
   var buildsStream = readStream;
 
@@ -805,6 +778,7 @@ Server.prototype.routes.get.builds = function(req, res, next) {
   }
 
   buildsStream.pipe(jsonStream).pipe(res);
+  res.header('Content-Type', 'application/json');
   res.on('finish', next);
 };
 
@@ -895,15 +869,14 @@ Server.prototype.routes.post['builds/:id'] = function(req, res, next) {
 /**
  * Delete an individual build and its container
  *
- * @param {object} req - Restify request object.
- * @param {object} res - Restify response object.
- * @param {Function} next - The next middleware to call.
+ * @param {import('restify').Request} req - Restify request object.
+ * @param {import('restify').Response} res - Restify response object.
+ * @param {import('restify').Next} next - The next middleware to call.
  */
 Server.prototype.routes.del['builds/:id'] = function(req, res, next) {
-  var self = this;
-  self.getBuildData(req.params.id, function(err, build) {
+  this.getBuildData(req.params.id, (err, build) => {
     if (err) {
-      self.log.error({buildId: req.params.id}, `Problem getting build data: ${err.message}`);
+      this.log.error({buildId: req.params.id}, `Problem getting build data: ${err.message}`);
       return next(err);
     }
 
@@ -912,17 +885,48 @@ Server.prototype.routes.del['builds/:id'] = function(req, res, next) {
       logContext.buildId = build.id;
     }
     if (build && build.container && build.container.id) {
+
       logContext.containerId = build.container.id;
-      self.log.info(logContext, 'Deleteing build and its container');
-      // overwrite the id param in the request
-      // and send request to container delete method
-      req.params.id = build.container.id;
-      self.deleteContainer(req, res, next);
+      this.log.info(logContext, 'Deleting build and its container');
+
+      let containerId = build.container.id;
+
+      let reapInfo = {
+        reason: req.query.reason || 0,
+        reasonText: (req.query.reasonText) ? decodeURIComponent(req.query.reasonText) : 'This build was deleted for an unknown reason.',
+        reapedDate: req.query.reapedDate || Date.now(),
+        force: req.query.force,
+      };
+
+      try {
+        this.deleteContainer(containerId, build, reapInfo, (err, build) => {
+
+          if (err) throw err;
+
+          this.storeBuildData(build, () => {
+            emitBuildEvent(build, constants.BUILD_EVENT_REAPED, {}, {log: this.log, producer: this.buildEventsProducer});
+
+            res.json({status: 'removed', id: containerId});
+
+            return next();
+          });
+
+        });
+      }
+      catch (err) {
+        this.log.error({err: err}, 'Could not delete container');
+
+        let message = `Could not delete container: ${err.message}`;
+        res.send(500, {error: message.trim(), code: 500});
+      }
+
     }
     else {
-      self.log.info({buildId: req.params.id}, `Build ${req.params.id} could not be deleted because the container was not found.`);
+      this.log.info({buildId: req.params.id},
+        `Build ${req.params.id} could not be deleted because the container was not found.`);
+
       res.writeHead(200);
-      res.end(JSON.stringify({error: 'Contianer not found'}));
+      res.end(JSON.stringify({error: 'Container not found'}));
     }
   });
 };

--- a/lib/GithubHandler.js
+++ b/lib/GithubHandler.js
@@ -119,8 +119,27 @@ var GithubHandler = function(options) {
     });
   };
 
+<<<<<<< HEAD
   this.server.post('/builds/:bid/status/:context', restify.jsonBodyParser(), buildStatusController);
   this.server.post('/update', restify.jsonBodyParser(), buildStatusController);
+=======
+  /**
+   * The handler for pull request events from GitHub webhooks.
+   *
+   * @param {Object.<string, any>} event - The pull request event.
+   * @param {(err: Error, [res]) => void} cb cb - The callback to be called after the update is performed.
+   */
+  pullRequestHandler(event, cb) {
+    this.logger.info('Github Pull request ' + event.payload.pull_request.id + ' received');
+
+    // We only want to take action on open and synchronize events (for
+    // now, we'll seen want to take action on close events as well).
+    if (event.payload.action !== 'opened' && event.payload.action !== 'synchronize') {
+      this.logger.info(`Github Pull request ${event.payload.pull_request.id} ${event.payload.action} ignored`);
+
+      return;
+    }
+>>>>>>> 7a66df9... Allow only removal of builds and remove containers in that endpoint
 
   this.log = log;
 

--- a/lib/GithubHandler.js
+++ b/lib/GithubHandler.js
@@ -119,27 +119,8 @@ var GithubHandler = function(options) {
     });
   };
 
-<<<<<<< HEAD
   this.server.post('/builds/:bid/status/:context', restify.jsonBodyParser(), buildStatusController);
   this.server.post('/update', restify.jsonBodyParser(), buildStatusController);
-=======
-  /**
-   * The handler for pull request events from GitHub webhooks.
-   *
-   * @param {Object.<string, any>} event - The pull request event.
-   * @param {(err: Error, [res]) => void} cb cb - The callback to be called after the update is performed.
-   */
-  pullRequestHandler(event, cb) {
-    this.logger.info('Github Pull request ' + event.payload.pull_request.id + ' received');
-
-    // We only want to take action on open and synchronize events (for
-    // now, we'll seen want to take action on close events as well).
-    if (event.payload.action !== 'opened' && event.payload.action !== 'synchronize') {
-      this.logger.info(`Github Pull request ${event.payload.pull_request.id} ${event.payload.action} ignored`);
-
-      return;
-    }
->>>>>>> 7a66df9... Allow only removal of builds and remove containers in that endpoint
 
   this.log = log;
 


### PR DESCRIPTION
Currently, there are two ways of deleting a build. The `DELETE build/:build` is used for manual deletion in Probo Coordinator while `DELETE container/:container` is used by the reaper.

Both endpoints end up calling the same function and cause overheads (build object is retrieved twice on manual deletion!). We really just need one of the endpoints.