### PR TITLE
Add Node.js plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
   "extends": "./node_modules/eslint-config-probo/index.js",
   "parserOptions": {
     "ecmaVersion": 2017
+  },
+  "rules": {
+    "valid-jsdoc": "off"
   }
 }

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -165,6 +165,10 @@ images:
         command: 'service varnish start'
       php_log:
         command: 'tail -F /var/log/php/error.log'
+  # This is an empty image with no default services.
+  'proboci/ubuntu:18.04':
+    services: null
+
 dataDir: './container-manager-data'
 # Volumes to mount into created containers.
 binds: []

--- a/lib/Container.js
+++ b/lib/Container.js
@@ -1,13 +1,14 @@
 'use strict';
-var Docker = require('dockerode');
-var through2 = require('through2');
-var bunyan = require('bunyan');
-var Promise = require('bluebird');
-var util = require('util');
-var EventEmitter = require('events').EventEmitter;
 
-var TaskRunnerPlugins = require('./plugins/TaskRunner');
-var AssetDownloader = require('./plugins/TaskRunner/AssetDownloader');
+const bunyan = require('bunyan');
+const Docker = require('dockerode');
+const EventEmitter = require('events').EventEmitter;
+const Promise = require('bluebird');
+const through2 = require('through2');
+
+const AssetDownloader = require('./plugins/TaskRunner/AssetDownloader');
+const startup = require('./container_manager/startup');
+const TaskRunnerPlugins = require('./plugins/TaskRunner');
 
 // patch dockerode's container.inspect to take opts
 require('./_patchDockerodeInspect');
@@ -15,404 +16,516 @@ require('./_patchDockerodeInspect');
 const ASSET_DIR = '/assets';
 const SRC_DIR = '/src';
 
-
-/**
- * Constructor for the container model.
- * @class
- *
- * @param {object} options - An options hash.
- * @param {object} options.assets - Assets server configuration for AssetDownloader.
- * @param {string} options.assets.url - Assets server URL.
- * @param {string} [options.assets.token] - API token for assets server.
- */
-var Container = function(options) {
-  this.create = this.create.bind(this);
-  this.docker = new Docker(options.docker);
-  this.build = options.build;
-  this.jobConfig = options.jobConfig;
-  this.log = options.log ? options.log.child({component: 'container'}) : bunyan.createLogger({name: 'container'});
-  this.containerName = options.containerName || null;
-  this.containerId = options.containerId || null;
-  this.container = this.containerId ? this.docker.getContainer(this.containerId) : null;
-  this.image = options.image;
-  this.imageConfig = options.imageConfig;
-  this.binds = options.binds || [];
-  // Whether to attach to log output.
-  this.attachLogs = options.attachLogs || false;
-  this.assetsOpts = options.assets;
-  this.authUrl = options.authUrl;
-
-  EventEmitter.call(this);
-
-  // wrap emit method to also emit a generic event
-  var _emit = this.emit;
-  this.emit = function(event) {
-    var args = Array.prototype.slice.call(arguments);
-
-    // emit original event
-    _emit.apply(this, args);
-
-    // emit a "stateChange" event
-    args.unshift('stateChange');
-    _emit.apply(this, args);
-  };
-};
-util.inherits(Container, EventEmitter);
-
-Container.prototype.buildSetupTasks = Promise.promisify(function(done) {
-  var jobConfig = this.jobConfig;
-
-  var container = this;
-  var build = this.build;
-  var project = build.project;
-
-  var tasks = [];
-
-  // 1. Download the code
-  var downloadSource = this._createDownloader(build, project);
-  tasks.push(downloadSource);
-
-  // 2. Download the assets
-  if (jobConfig.assets && this.assetsOpts) {
-    this.assetsOpts.bucket = (project.assets && project.assets.bucket) || project.id;
-    this.assetsOpts.assets = jobConfig.assets;
-    var ad = new AssetDownloader(container, this.assetsOpts);
-    tasks.push(ad);
-  }
-
-  done(null, tasks);
-});
-
-Container.prototype._createDownloader = function(build, project) {
-  // map provider type to downloader class name
-  var downloaders = {
-    github: 'GithubDownloader',
-    gitlab: 'GitlabDownloader',
-    stash: 'StashDownloader',
-    bitbucket: 'BitbucketDownloader',
-  };
-
-  var providerType = project.provider.type;
-  var plugin = downloaders[providerType];
-  if (!plugin) {
-    throw new Error('Download: unsupported provider type: ' + providerType);
-  }
-
-  // dynamically require and instantiate a downloder
-  var Downloader;
-  try {
-    Downloader = require(`./plugins/TaskRunner/${plugin}`);
-  }
-  catch (e) {
-    var msg = `Download: failed to load supported downloader for provider ${providerType}: ${e.message}`;
-    this.log.error({err: e, plugin}, msg);
-    throw new Error(msg);
-  }
-
-  return new Downloader(this, {build, project, auth_lookup_url: this.authUrl});
-};
-
-Container.prototype.buildUserTasks = Promise.promisify(function(done) {
-  var self = this;
-  var config = this.jobConfig;
-  var tasks = [];
-  var steps = config.steps || [];
-  steps = Array.isArray(steps) ? steps : [steps];
-
-  steps.forEach(function(step) {
-    var plugin = step.plugin || 'Shell';
-
-    if (self.provisionerPlugins[plugin]) {
-      var task = new self.provisionerPlugins[plugin](self, step);
-      tasks.push(task);
-    }
-  });
-
-  done(null, tasks);
-});
-
-/**
- * First class Promise method.
- *
- * helper method to run scripts, not
- * useful in an app because it doesn't pass up stream before its piped
- * out
- *
- * @return {booelean} - The status of the tasks.
- */
-Container.prototype.runTasks = function() {
-  this.emit('running tasks');
-
-  var self = this;
-  return this.buildUserTasks().each(function(task) {
-    return task.run().then(function(result) {
-      // result: {stream, exec (Promise), task}
-      result.streams.combined.pipe(process.stdout);
-      return result.exec.then(function(exec) {
-        console.log('Exit code:', exec.ExitCode);
-
-        self.emit('tasks complete', result);
-        return result;
-      });
-    });
-  });
-};
-
-Container.prototype.runBuild = Promise.promisify(function(done) {
-  var self = this;
-  self.create(function(error, containerData) {
-    if (error) return done(error);
-
-    return self.runTasks().then(function(EvaluatedTasks) {
-      return containerData;
-    }).nodeify(done);
-  });
-});
-
-/**
- * Creates and starts this Docker container.
- *
- * The done callback will be called with errors (if one occured).
- */
-Container.prototype.create = Promise.promisify(function(done) {
-  this.emit('creating');
-  done = wrapCallbackWithEmitter(this, 'created', done);
-
-  let self = this;
-  let docker = this.docker;
-
-  var commandInfo = self.buildCommandInfo(self.imageConfig);
-
-  let branchName = this.build.branch ? this.build.branch.name : null;
-  let branchLink = this.build.branch ? this.build.branch.htmlUrl : null;
-
-  let createOptions = {
-    name: self.containerName,
-    Image: self.image,
-    ExposedPorts: commandInfo.exposedPorts,
-    PortBindings: commandInfo.portBindings,
-    Cmd: commandInfo.command,
-    Env: [
-      `ASSET_DIR=${ASSET_DIR}`,
-      `BRANCH_NAME=${branchName}`,
-      `BRANCH_LINK=${branchLink}`,
-      `BUILD_ID=${this.build.id}`,
-      `COMMIT_REF=${this.build.commit.ref}`,
-      `COMMIT_LINK=${this.build.commit.htmlUrl}`,
-      `PWD=${SRC_DIR}`,
-      'PROBO_ENVIRONMENT=TRUE',
-      `SRC_DIR=${SRC_DIR}`,
-    ],
-  };
-  if (this.build.links && this.build.links.build) {
-    createOptions.Env.push(`BUILD_DOMAIN=${this.build.links.build}`);
-  }
-  if (this.build.pullRequest) {
-    if (this.build.pullRequest.htmlUrl) {
-      createOptions.Env.push(`PULL_REQUEST_LINK=${this.build.pullRequest.htmlUrl}`);
-    }
-    if (this.build.pullRequest.name) {
-      createOptions.Env.push(`PULL_REQUEST_NAME="${this.build.pullRequest.name}"`);
-    }
-  }
-  self.log.info({env: createOptions.Env}, `Creating container for build ${this.build.id}`);
-  docker.createContainer(createOptions, function(error, container) {
-    if (error) return done(error);
-    self.id = container.id;
-    self.container = container;
-    if (error) return done(error);
-    self.log.info(`Created container ${container.id}`);
-    self.log.info(`Starting container ${container.id}`);
-    if (self.attachLogs) {
-      container.attach({stream: true, stdout: true, stderr: true}, function(error, stream) {
-        // TODO: We should consider collecting log output from the node and
-        // sending it to loom.
-        container.modem.demuxStream(stream, self.createLogWriteStream(), self.createLogWriteStream());
-      });
-    }
-    container.start(function(error, data) {
-      if (error) return done(error);
-      container.inspect(function(error, data) {
-        self.containerInfo = data;
-        done(error, data);
-      });
-    });
-  });
-});
-
-/**
- * Tries to create a container or finds one by the ID instead
- */
-Container.prototype.findOrCreate = function() {
-
-};
-
-/**
- * Returns the current status of the container
- *
- * @param {function} done - the callback function, if provided
- * @return {function} - container inspect funnction, callback or promise
- */
-Container.prototype.getState = function(done) {
-  return this.inspect()
-    .then(function(info) { return info.State; })
-    .asCallback(done);
-};
-
-/**
- * Returns result of .inspect on container
- */
-Container.prototype.inspect = Promise.promisify(function(opts, done) {
-  if (typeof opts == 'function') {
-    done = opts;
-    opts = {};
-  }
-  this.container.inspect(opts, function(err, info) {
-    return done(err, info);
-  });
-});
-
-/**
- * Stop the container
- */
-Container.prototype.stop = Promise.promisify(function(done) {
-  this.emit('stopping');
-  done = wrapCallbackWithEmitter(this, 'stopped', done);
-  this.container.stop(done);
-});
-
-/**
- * restart (stop/start) container
- */
-Container.prototype.restart = Promise.promisify(function(done) {
-  this.emit('restarting');
-  done = wrapCallbackWithEmitter(this, 'restarted', done);
-  this.container.restart(done);
-});
-
-/**
- * start container
- */
-Container.prototype.start = Promise.promisify(function(done) {
-  this.emit('starting');
-  done = wrapCallbackWithEmitter(this, 'started', done);
-  this.container.start(done);
-});
-
-
-/**
- * DELETE container from the filesystem
- */
-Container.prototype.remove = Promise.promisify(function(opts, done) {
-  this.emit('removing');
-
-  if (typeof opts == 'function') {
-    done = opts;
-    opts = {};
-  }
-
-  done = wrapCallbackWithEmitter(this, 'removed', done);
-  this.container.remove(opts, done);
-});
-
-/**
- * Retrieve container info getter.
- *
- * @param {object} data - container info data
- * @param {number} port - port number used on container
- * @return {function} - function to get container info
- */
-Container.prototype.getExposedPortFromContainerInfo = function(data, port) {
-  try {
-    return data.NetworkSettings.Ports[port + '/tcp'][0].HostPort;
-  }
-  catch (e) {
-    throw new Error('Could not find tcp port ' + port + ' on container ' + this.id);
-  }
-};
-
-/**
- * Gets the disk usage of the container.
- * Current implementation requires the AUFS
- * Storage driver and to be run as root.
- * Errors if there's no root access or not using the AUFS driver
- *
- * @param {Function} done - callback that takes err and an object as
- *  arguments. The object has {virtualBytes, realBytes}, for the
- *  size of the inderlying image and container layer respectively.
- */
-Container.prototype.getDiskUsage = Promise.promisify(function(done) {
-  var result = {realBytes: null, virtualBytes: null};
-
-  // stat the container to ensure that it's using the AUFS driver
-  this.container.inspect({size: true}, function(err, info) {
-    if (err) {
-      return done(null, result);
-    }
-
-    result.realBytes = (info.SizeRw || null);
-    result.virtualBytes = (info.SizeRootFs || null);
-    done(null, result);
-  });
-});
-
-/**
- * Build the command and port exposing logic for starting a proboscis powered container.
- *
- * @param {string} image - The name of the image we are extracting build command info for.
- * @return {object} - The command info on what is to be run.
- */
-Container.prototype.buildCommandInfo = function(image) {
-  if (!image) {
-    throw new Error('Use an approved Probo Image in your .probo.yaml file. See https://docs.probo.ci/build/images/ for approved Probo Images.');
-  }
-
-  var command = ['proboscis'];
-  var exposedPorts = {};
-  var portBindings = {};
-  for (let name in image.services) {
-    if (image.services.hasOwnProperty(name)) {
-      var service = image.services[name];
-      command.push('-n');
-      command.push(name);
-      command.push('-c');
-      command.push(service.command);
-      if (service.port) {
-        var protocol = service.protocol || 'tcp';
-        var portString = service.port + '/' + protocol;
-        exposedPorts[portString] = {};
-        portBindings[portString] = [{HostPort: null}];
-      }
-    }
-  }
-  return {
-    command: command,
-    exposedPorts: exposedPorts,
-    portBindings: portBindings,
-  };
-};
-
-Container.prototype.provisionerPlugins = TaskRunnerPlugins;
-
-/**
- * Get a log handler stream appropriate to piping output to.
- *
- * @param {object} options Options to pass to for the creation of the log stream.
- * @return {stream} - The stream to write log files to.
- */
-Container.prototype.createLogWriteStream = function(options) {
-  var stream = through2();
-  stream.pipe(process.stdout);
-  return stream;
-};
-
 function wrapCallbackWithEmitter(emitter, eventName, callback) {
   return function() {
     var args = Array.prototype.slice.call(arguments);
     args.unshift(eventName);
     emitter.emit.apply(emitter, args);
-    callback.apply(emitter, arguments);
+
+    if (callback) {
+      callback.apply(emitter, arguments);
+    }
   };
+}
+
+class Container extends EventEmitter {
+
+  /**
+   * Constructor for the container model.
+   * @class
+   *
+   * @param {object} options - An options hash.
+   * @param {object} options.assets - Assets server configuration for AssetDownloader.
+   * @param {string} options.assets.url - Assets server URL.
+   * @param {string} [options.assets.token] - API token for assets server.
+   */
+  constructor(options) {
+    super(options);
+
+    this.provisionerPlugins = TaskRunnerPlugins;
+
+    this.docker = new Docker(options.docker);
+    this.build = options.build;
+    this.jobConfig = options.jobConfig;
+    this.log = options.log ? options.log.child({component: 'container'}) : bunyan.createLogger({name: 'container'});
+    this.containerName = options.containerName || null;
+    this.id = options.containerId || null;
+    this.container = this.id ? this.docker.getContainer(this.id) : null;
+    this.image = options.image;
+    this.imageConfig = options.imageConfig;
+    this.binds = options.binds || [];
+
+    // Whether to attach to log output.
+    this.attachLogs = options.attachLogs || false;
+    this.assetsOpts = options.assets;
+    this.authUrl = options.authUrl;
+
+    this.create = this.create.bind(this);
+
+    // wrap emit method to also emit a generic event
+    var _emit = this.emit;
+    this.emit = function(event) {
+      var args = Array.prototype.slice.call(arguments);
+
+      // emit original event
+      _emit.apply(this, args);
+
+      // emit a "stateChange" event
+      args.unshift('stateChange');
+      _emit.apply(this, args);
+    };
+  }
+
+  buildSetupTasks(cb) {
+    var jobConfig = this.jobConfig;
+
+    var container = this;
+    var build = this.build;
+    var project = build.project;
+
+    var tasks = [];
+
+    return new Promise(resolve => {
+      // 1. Download the code
+      var downloadSource = this._createDownloader(build, project);
+      tasks.push(downloadSource);
+
+      // 2. Download the assets
+      if (jobConfig.assets && this.assetsOpts) {
+        this.assetsOpts.bucket = (project.assets && project.assets.bucket) || project.id;
+        this.assetsOpts.assets = jobConfig.assets;
+        var ad = new AssetDownloader(container, this.assetsOpts);
+        tasks.push(ad);
+      }
+
+      resolve(tasks);
+    })
+      .nodeify(cb);
+  }
+
+  _createDownloader(build, project) {
+    // map provider type to downloader class name
+    var downloaders = {
+      github: 'GithubDownloader',
+      gitlab: 'GitlabDownloader',
+      stash: 'StashDownloader',
+      bitbucket: 'BitbucketDownloader',
+    };
+
+    var providerType = project.provider.type;
+    var plugin = downloaders[providerType];
+    if (!plugin) {
+      throw new Error('Download: unsupported provider type: ' + providerType);
+    }
+
+    // dynamically require and instantiate a downloder
+    var Downloader;
+    try {
+      Downloader = require(`./plugins/TaskRunner/${plugin}`);
+    }
+    catch (e) {
+      var msg = `Download: failed to load supported downloader for provider ${providerType}: ${e.message}`;
+      this.log.error({err: e, plugin}, msg);
+      throw new Error(msg);
+    }
+
+    return new Downloader(this, {build, project, auth_lookup_url: this.authUrl});
+  }
+
+  buildUserTasks(cb) {
+    var self = this;
+    var config = this.jobConfig;
+    var tasks = [];
+
+    return new Promise(resolve => {
+      var steps = config.steps || [];
+      steps = Array.isArray(steps) ? steps : [steps];
+
+      steps.forEach(function(step) {
+        var plugin = step.plugin || 'Shell';
+
+        if (self.provisionerPlugins[plugin]) {
+          var task = new self.provisionerPlugins[plugin](self, step);
+          tasks.push(task);
+        }
+      });
+
+      resolve(tasks);
+    })
+      .nodeify(cb);
+  }
+
+  /**
+   * First class Promise method.
+   *
+   * helper method to run scripts, not
+   * useful in an app because it doesn't pass up stream before its piped
+   * out
+   *
+   * @return {boolean} - The status of the tasks.
+   */
+  runTasks() {
+    this.emit('running tasks');
+
+    var self = this;
+    return this.buildUserTasks().each(function(task) {
+      return task.run().then(function(result) {
+        // result: {stream, exec (Promise), task}
+        result.streams.combined.pipe(process.stdout);
+        return result.exec.then(function(exec) {
+          console.log('Exit code:', exec.ExitCode);
+
+          self.emit('tasks complete', result);
+          return result;
+        });
+      });
+    });
+  }
+
+  runBuild(cb) {
+    var self = this;
+    self.create(function(error, containerData) {
+      if (error) return cb(error);
+
+      return self.runTasks().then(function(EvaluatedTasks) {
+        return containerData;
+      })
+        .nodeify(cb);
+
+    });
+  }
+
+  /**
+   * Creates and starts this Docker container.
+   *
+   * The callback will be called with errors (if one occured).
+   *
+   * @param {(err: Error) => void} cb - The callback function.
+   * @return {import('bluebird')}
+   */
+  create(cb) {
+    this.emit('creating');
+    cb = wrapCallbackWithEmitter(this, 'created', cb);
+
+    const docker = this.docker;
+    const options = this.getCreateOptions();
+
+    return new Promise((resolve, reject) => {
+
+      this.log.info({env: options.Env}, `Creating container for build ${this.build.id}`);
+
+      docker.createContainer(options, (error, container) => {
+        if (error) return reject(error);
+
+        this.id = container.id;
+        this.container = container;
+
+        this.log.info(`Created container ${container.id}`);
+        this.log.info(`Starting container ${container.id}`);
+
+        if (this.attachLogs) {
+          container.attach({stream: true, stdout: true, stderr: true}, (error, stream) => {
+            // TODO: We should consider collecting log output from the node and
+            // sending it to loom.
+            container.modem.demuxStream(stream, self.createLogWriteStream(), self.createLogWriteStream());
+          });
+        }
+
+        return this.firstStart(container, options.command)
+          .then(containerInfo => {
+            this.containerInfo = containerInfo;
+
+            return resolve(containerInfo);
+          })
+          .catch(err => reject(err));
+
+      });
+    })
+      .nodeify(cb);
+
+  }
+
+  /**
+   * Returns the create option values for a container.
+   *
+   * This also returns the command to run the default services for the selected
+   * image under the key `command`.
+   *
+   * `startup.sh` has initially something 'dummy' like `tail -f /dev/null`
+   * just to keep the container running. It is later overwritten to include the
+   * services to run when re-starting the container.
+   * @see `processAtStart`
+   *
+   * @return {Object.<string, any>} - The options for a container creation.
+   */
+  getCreateOptions() {
+
+    var commandInfo = startup.defaultCommandInfo(this.imageConfig, this.build.config);
+
+    let branchName = this.build.branch ? this.build.branch.name : null;
+    let branchLink = this.build.branch ? this.build.branch.htmlUrl : null;
+
+    let options = {
+      name: this.containerName,
+      Image: this.image,
+      ExposedPorts: commandInfo.exposedPorts,
+      PortBindings: commandInfo.portBindings,
+      Cmd: ['/bin/bash', '-c', '/startup.sh'],
+      Env: [
+        `ASSET_DIR=${ASSET_DIR}`,
+        `BRANCH_NAME=${branchName}`,
+        `BRANCH_LINK=${branchLink}`,
+        `BUILD_ID=${this.build.id}`,
+        `COMMIT_REF=${this.build.commit.ref}`,
+        `COMMIT_LINK=${this.build.commit.htmlUrl}`,
+        `PWD=${SRC_DIR}`,
+        'PROBO_ENVIRONMENT=TRUE',
+        `SRC_DIR=${SRC_DIR}`,
+      ],
+
+      command: commandInfo.command,
+    };
+
+    if (this.build.links && this.build.links.build) {
+      options.Env.push(`BUILD_DOMAIN=${this.build.links.build}`);
+    }
+
+    if (this.build.pullRequest) {
+      if (this.build.pullRequest.htmlUrl) {
+        options.Env.push(`PULL_REQUEST_LINK=${this.build.pullRequest.htmlUrl}`);
+      }
+      if (this.build.pullRequest.name) {
+        options.Env.push(`PULL_REQUEST_NAME="${this.build.pullRequest.name}"`);
+      }
+    }
+
+    return options;
+  }
+
+  /**
+   * This is called right after the container is created.
+   *
+   * It makes sure the default services for the image are run before running any
+   * of the other steps. This method also overrides the `/startup.sh` file to
+   * include the default services + services declared in the .probo.yaml file.
+   *
+   * @param {import('dockerode').Container} container - The created container.
+   * @param {string} command - The command to run the default services.
+   */
+  async firstStart(container, command) {
+
+    try {
+      await container.start();
+
+      await this.processAtStart(container, command);
+
+      let data = await container.inspect();
+
+      return data;
+    }
+    catch (e) {
+      this.log.error({err: e}, 'Error starting new container');
+
+      return e;
+    }
+  }
+
+  /**
+   * Creates and runs docker exec instances for a new container.
+   *
+   * This method runs two main processes. The first one is proboscis with the
+   * default services for the image. The second process uses `echo` to overwrite
+   * the `startup.sh` file to include the default services + the user-defined
+   * services, which will all be run once the container restarts.
+   *
+   * @param {import('dockerode').Container} container - The created container.
+   * @param {string} command - The command to run the default services.
+   */
+  async processAtStart(container, command) {
+
+    try {
+      // Starts the default services before proceding with any steps.
+      let exec = await container.exec({Cmd: ['/bin/bash', '-c', command]});
+      await exec.start();
+
+      // Appends the user-defined services to the default services and save them
+      // in the startup script.
+      command = startup.appendServices(command, this.build.config.services);
+      let cmd = ['/bin/bash', '-c', `echo '${command}' > /startup.sh`];
+
+      exec = await container.exec({Cmd: cmd});
+      await exec.start();
+    }
+    catch (e) {
+      this.log.error({error: e}, 'Error creating or running exec instances for new container');
+
+      return e;
+    }
+  }
+
+  /**
+   * Returns the current status of the container
+   *
+   * @param {function} cb - the callback function, if provided
+   * @return {function} - container inspect funnction, callback or promise
+   */
+  getState(cb) {
+    return this.inspect()
+      .then(function(info) { return info.State; })
+      .asCallback(cb);
+  }
+
+  /**
+   * Returns result of .inspect on container.
+   *
+   * @param {Object.<string, any>} opts - The options for the inspect call.
+   * @param {(err: Error, info)} cb - The callback function.
+   * @return {import('bluebird')}
+   */
+  inspect(opts, cb) {
+    return new Promise((resolve, reject) => {
+      this.container.inspect(opts, function(err, info) {
+        if (err) return reject(err);
+
+        return resolve(info);
+      });
+    })
+      .nodeify(cb);
+  }
+
+  /**
+   * Stops the container.
+   *
+   * @param {(err: Errr)} cb - The callback function.
+   * @return {import('bluebird')}
+   */
+  stop(cb) {
+    return new Promise((resolve, reject) => {
+      this.emit('stopping');
+
+      this.container.stop(err => {
+        if (err) return reject(err);
+      });
+
+      resolve();
+    })
+      .nodeify(cb);
+  }
+
+  /**
+   * Restarts (stop/start) container.
+   *
+   * @param {(err: Error)} cb - The callback function.
+   * @return {import('bluebird')}
+   */
+  restart(cb) {
+    return new Promise((resolve, reject) => {
+      this.emit('restarting');
+      cb = wrapCallbackWithEmitter(this, 'restarted', cb);
+
+      this.container.restart(err => {
+        if (err) return reject(err);
+      });
+
+      resolve();
+    })
+      .nodeify(cb);
+  }
+
+  /**
+   * Starts container.
+   *
+   * @param {(err: Error)} cb - The callback function.
+   * @return {import('bluebird')}
+   */
+  start(cb) {
+    return new Promise((resolve, reject) => {
+      this.emit('starting');
+      cb = wrapCallbackWithEmitter(this, 'started', cb);
+
+      this.container.start(err => {
+        if (err) return reject(err);
+      });
+
+      resolve();
+    })
+      .nodeify(cb);
+  }
+
+  /**
+   * Deletes container from the filesystem.
+   *
+   * @param {(err: Error)} cb - The callback function.
+   * @return {import('bluebird')}
+   */
+  remove(opts, cb) {
+    return new Promise((resolve, reject) => {
+      this.emit('removing');
+
+      cb = wrapCallbackWithEmitter(this, 'removed', cb);
+
+      this.container.remove(opts, err => {
+        if (err) return reject(err);
+      });
+
+      resolve();
+    })
+      .nodeify(cb);
+  }
+
+  /**
+   * Retrieve container info getter.
+   *
+   * @param {object} data - container info data
+   * @param {number} port - port number used on container
+   * @return {function} - function to get container info
+   */
+  getExposedPortFromContainerInfo(data, port) {
+    try {
+      return data.NetworkSettings.Ports[port + '/tcp'][0].HostPort;
+    }
+    catch (e) {
+      throw new Error('Could not find tcp port ' + port + ' on container ' + this.id);
+    }
+  }
+
+  /**
+   * Gets the disk usage of the container.
+   * Current implementation requires the AUFS
+   * Storage driver and to be run as root.
+   * Errors if there's no root access or not using the AUFS driver
+   *
+   * @param {Function} cb - callback that takes err and an object as
+   *  arguments. The object has {virtualBytes, realBytes}, for the
+   *  size of the inderlying image and container layer respectively.
+   */
+  getDiskUsage(cb) {
+    var result = {realBytes: null, virtualBytes: null};
+
+    // stat the container to ensure that it's using the AUFS driver
+    this.container.inspect({size: true}, function(err, info) {
+      if (err) {
+        return cb(null, result);
+      }
+
+      result.realBytes = (info.SizeRw || null);
+      result.virtualBytes = (info.SizeRootFs || null);
+      cb(null, result);
+    });
+  }
+
+  /**
+   * Get a log handler stream appropriate to piping output to.
+   *
+   * @param {object} options Options to pass to for the creation of the log stream.
+   * @return {stream} - The stream to write log files to.
+   */
+  createLogWriteStream(options) {
+    var stream = through2();
+    stream.pipe(process.stdout);
+    return stream;
+  }
+
 }
 
 module.exports = Container;

--- a/lib/ContainerManager.js
+++ b/lib/ContainerManager.js
@@ -526,7 +526,6 @@ Server.prototype.routes.get.containers = function(req, res, next) {
  * @param {(err: Error, build: any) => void} cb - The callback function.
  */
 Server.prototype.deleteContainer = function(containerId, build, reapInfo, cb) {
-
   let container = new Container({
     docker: this.config.docker,
     containerId: containerId,
@@ -535,7 +534,7 @@ Server.prototype.deleteContainer = function(containerId, build, reapInfo, cb) {
 
   logContainerEvents(container);
 
-  container.inspect(err => {
+  container.inspect({}, err => {
     if (err) {
       // If container was already removed, continue so we can update build.
       if (err.statusCode !== 404) {
@@ -672,11 +671,10 @@ Server.prototype.routes.post['container/proxy'] = function(req, res, next) {
 
       self.resetContainerIdleTimeout(container, setIdleTimeout, log);
 
-      // find port 80 mapping for this container
-      var targetPort = 80;
+      // Find port the port set by user in .probo.yaml or 80 if none is set.
+      var targetPort = build.config.sitePort ? build.config.sitePort : 80;
       var inspectInfo = yield container.inspect();
       var exposedHostPort = container.getExposedPortFromContainerInfo(inspectInfo, targetPort);
-
 
       // wait for the port to be up before responding if it's not up yet
       var up = true;

--- a/lib/container_manager/startup.js
+++ b/lib/container_manager/startup.js
@@ -1,0 +1,104 @@
+'use strict';
+
+/**
+ * Build the command and port exposing logic for starting a proboscis powered
+ * container.
+ *
+ * This only takes care of the default services for the image defined by us.
+ * @see `defaults.yaml`
+ *
+ * @param {Object.<string, any>} image - The image configuration.
+ * @param {Object.<string, any>} image.services - The default services for the
+ *   image.
+ * @param {Object.<string, any>} buildConfig - The build configuration defined
+ *   in the .probo.yaml file.
+ * @return {Object.<string, any>} - The command info on what is to be run.
+ */
+const defaultCommandInfo = (image, buildConfig) => {
+  if (!image) {
+    throw new Error('Use an approved Probo Image in your .probo.yaml file. See https://docs.probo.ci/build/images/ for approved Probo Images.');
+  }
+
+  if (!image.services) {
+    return emptyDefaultCommand(buildConfig);
+  }
+
+  let command = 'proboscis';
+  let exposedPorts = {};
+  let portBindings = {};
+
+  for (let name in image.services) {
+    if (image.services.hasOwnProperty(name)) {
+      const service = image.services[name];
+
+      command += ` -n ${name} -c "${service.command}"`;
+
+      if (service.port) {
+        const protocol = service.protocol || 'tcp';
+        const portString = service.port + '/' + protocol;
+
+        exposedPorts[portString] = {};
+        portBindings[portString] = [{HostPort: null}];
+      }
+    }
+  }
+
+  // Exposes the configured site port or 80 if none is set by user.
+  const port = buildConfig.sitePort ? buildConfig.sitePort : '80';
+  exposedPorts[`${port}/tcp`] = {};
+  portBindings[`${port}/tcp`] = [{HostPort: null}];
+
+  return {
+    command: command,
+    exposedPorts: exposedPorts,
+    portBindings: portBindings,
+  };
+
+};
+
+const emptyDefaultCommand = buildConfig => {
+  let options = {
+    command: '',
+    exposedPorts: {},
+    portBindings: {},
+  };
+
+  const port = buildConfig.sitePort ? buildConfig.sitePort : '80';
+
+  options.exposedPorts[`${port}/tcp`] = {};
+  options.portBindings[`${port}/tcp`] = [{HostPort: null}];
+
+  return options;
+};
+
+/**
+ * Appends user-defined services to the default services for the image.
+ *
+ * @param {string} command - The current proboscis command.
+ * @param {Object.<string, any>} services - The user-defined services to append.
+ * @return {string} - The new proboscis command with the previous services +
+ *   the new services.
+ */
+const appendServices = (command, services) => {
+
+  if (!command) {
+    command = 'proboscis';
+  }
+
+  for (let name in services) {
+    if (services.hasOwnProperty(name)) {
+
+      const service = services[name];
+
+      command += ` -n ${name} -c "${service.command}"`;
+
+    }
+  }
+
+  return command;
+};
+
+module.exports = {
+  defaultCommandInfo,
+  appendServices,
+};

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,7 +7,7 @@ class Logger {
   constructor() {
     this.logger = bunyan.createLogger({
       name: 'probo',
-      level: 'error',
+      level: 'debug',
       src: true,
       streams: [
         {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,7 +7,7 @@ class Logger {
   constructor() {
     this.logger = bunyan.createLogger({
       name: 'probo',
-      level: 'debug',
+      level: 'error',
       src: true,
       streams: [
         {

--- a/lib/plugins/TaskRunner/LAMPApp.js
+++ b/lib/plugins/TaskRunner/LAMPApp.js
@@ -4,7 +4,6 @@ var Script = require('./Script');
 
 class LAMPApp extends Script {
 
-
   /**
    * Options (used by this task):
    *   @param {object} container - An instantiated and configured Container object.

--- a/lib/plugins/TaskRunner/Node.js
+++ b/lib/plugins/TaskRunner/Node.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const Script = require('./Script');
+
+class Node extends Script {
+
+  /**
+   * @param {Object.<string, any>} container - An instantiated and configured
+   *   Container object.
+   * @param {Object.<string, any>} options - Configuration options specific to
+   *   this task.
+   * @param {string} options.nodeVersion - The node version to use.
+   * @param {string} options.mainFile - The entry file to run the application.
+   */
+  constructor(container, options) {
+
+    super(container, options);
+
+    this.version = options.nodeVersion || '10.16.3';
+    this.main = options.mainFile || 'index.js';
+
+    this.script = [];
+    this.populateScriptArray();
+    this.setScript(this.script);
+  }
+
+  populateScriptArray() {
+    this.addScriptNvmInstall();
+    this.addScriptNodeInstall();
+    this.addScriptInitApp();
+  }
+
+  addScriptNvmInstall() {
+    this.script = this.script.concat([
+      'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash',
+      'export NVM_DIR="$HOME/.nvm"',
+      // Loads nvm.
+      '. "$NVM_DIR/nvm.sh"',
+    ]);
+  }
+
+  addScriptNodeInstall() {
+    this.script = this.script.concat([
+      `nvm install ${this.version} > /dev/null 2> /dev/null`,
+      `nvm alias default ${this.version}`,
+      'nvm use default',
+    ]);
+  }
+
+  addScriptInitApp() {
+    this.script = this.script.concat([
+      'npm install',
+    ]);
+  }
+
+}
+
+module.exports = Node;

--- a/lib/plugins/TaskRunner/index.js
+++ b/lib/plugins/TaskRunner/index.js
@@ -1,10 +1,11 @@
 'use strict';
 
 module.exports = {};
-module.exports.Shell = require('./Shell');
-module.exports.DrushFetcher = require('./DrushFetcher');
-module.exports.Script = require('./Script');
-module.exports.LAMPApp = require('./LAMPApp');
-module.exports.WordPressApp = require('./WordPressApp');
 module.exports.Drupal = require('./Drupal');
+module.exports.DrushFetcher = require('./DrushFetcher');
+module.exports.LAMPApp = require('./LAMPApp');
 module.exports.Lighthouse = require('./Lighthouse');
+module.exports.Node = require('./Node');
+module.exports.Script = require('./Script');
+module.exports.Shell = require('./Shell');
+module.exports.WordPressApp = require('./WordPressApp');

--- a/package-lock.json
+++ b/package-lock.json
@@ -4763,7 +4763,7 @@
       "requires": {
         "async": "^3.0.1",
         "kafka-node": "^3.0.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "through2": "^3.0.1"
       }
     },


### PR DESCRIPTION
This PR does two things:
1) It allows running any user-defined services on the start of a container
2) Adds a Node plugin

For 1:
* If the user chooses an image that does not have default services, the user must specify a service that runs on the foreground "forever".
* All images must be updated to include an executable `/startup.sh` file. Otherwise, this won't work.

For 2, take a look at https://github.com/Probo-Demos/probo-example-node