### PR TITLE
As per 3018415 the config_sync variable was removed from Drupal 9

### DIFF
--- a/lib/plugins/TaskRunner/Drupal.js
+++ b/lib/plugins/TaskRunner/Drupal.js
@@ -208,7 +208,7 @@ class Drupal extends LAMPApp {
       `  ),`,
       `);`,
       `\\$settings['hash_salt'] = '${random}';`,
-      `\\$config_directories['sync'] = '${configSyncDirectory}';`,
+      `\\$settings['config_sync_directory'] = '${configSyncDirectory}';`,
       `END_HEREDOC`,
       `)`,
       `if [ ! -e "/var/www/html/sites/${this.options.siteFolder}/settings.php" ] ; then`,


### PR DESCRIPTION
https://www.drupal.org/node/3018145